### PR TITLE
Replace StateHolder.values with custom map

### DIFF
--- a/src/main/java/ca/spottedleaf/moonrise/mixin/blockstate_propertyaccess/StateHolderMixin.java
+++ b/src/main/java/ca/spottedleaf/moonrise/mixin/blockstate_propertyaccess/StateHolderMixin.java
@@ -14,7 +14,6 @@ import org.spongepowered.asm.mixin.Unique;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
-
 import java.util.Collection;
 import java.util.Map;
 import java.util.Optional;

--- a/src/main/java/ca/spottedleaf/moonrise/mixin/blockstate_propertyaccess/StateHolderMixin.java
+++ b/src/main/java/ca/spottedleaf/moonrise/mixin/blockstate_propertyaccess/StateHolderMixin.java
@@ -168,7 +168,7 @@ abstract class StateHolderMixin<O, S> implements PropertyAccessStateHolder {
      */
     @Overwrite
     public Map<Property<?>, Comparable<?>> getValues() {
-        var table = this.optimisedTable;
+        ZeroCollidingReferenceStateTable<O, S> table = this.optimisedTable;
         // We have to use this.values until the table is loaded
         return table.isLoaded() ? table.getMapView(this.tableIndex) : this.values;
     }

--- a/src/main/java/ca/spottedleaf/moonrise/patches/blockstate_propertyaccess/util/ZeroCollidingReferenceStateTable.java
+++ b/src/main/java/ca/spottedleaf/moonrise/patches/blockstate_propertyaccess/util/ZeroCollidingReferenceStateTable.java
@@ -8,21 +8,16 @@ import it.unimi.dsi.fastutil.objects.AbstractObjectSet;
 import it.unimi.dsi.fastutil.objects.AbstractReference2ObjectMap;
 import it.unimi.dsi.fastutil.objects.ObjectIterator;
 import it.unimi.dsi.fastutil.objects.ObjectSet;
-import it.unimi.dsi.fastutil.objects.Reference2ObjectArrayMap;
 import it.unimi.dsi.fastutil.objects.Reference2ObjectMap;
 import it.unimi.dsi.fastutil.objects.ReferenceOpenHashSet;
-import net.minecraft.world.level.block.state.StateHolder;
-import net.minecraft.world.level.block.state.properties.Property;
-import org.jetbrains.annotations.NotNull;
-
-import java.util.AbstractMap;
-import java.util.AbstractSet;
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
-import java.util.Set;
+import net.minecraft.world.level.block.state.StateHolder;
+import net.minecraft.world.level.block.state.properties.Property;
 
 public final class ZeroCollidingReferenceStateTable<O, S> {
 
@@ -167,7 +162,7 @@ public final class ZeroCollidingReferenceStateTable<O, S> {
     }
 
     public Collection<Property<?>> getProperties() {
-        return this.properties;
+        return Collections.unmodifiableCollection(this.properties);
     }
 
     public Map<Property<?>, Comparable<?>> getMapView(final long stateIndex) {
@@ -188,7 +183,7 @@ public final class ZeroCollidingReferenceStateTable<O, S> {
 
         @Override
         public boolean containsKey(final Object key) {
-            return ZeroCollidingReferenceStateTable.this.properties.contains(key);
+            return key instanceof Property<?> prop && ZeroCollidingReferenceStateTable.this.hasProperty(prop);
         }
 
         @Override

--- a/src/main/java/ca/spottedleaf/moonrise/patches/blockstate_propertyaccess/util/ZeroCollidingReferenceStateTable.java
+++ b/src/main/java/ca/spottedleaf/moonrise/patches/blockstate_propertyaccess/util/ZeroCollidingReferenceStateTable.java
@@ -206,7 +206,7 @@ public final class ZeroCollidingReferenceStateTable<O, S> {
         class EntrySet extends AbstractObjectSet<Entry<Property<?>, Comparable<?>>> {
             @Override
             public ObjectIterator<Reference2ObjectMap.Entry<Property<?>, Comparable<?>>> iterator() {
-                Iterator<Property<?>> propIterator = properties.iterator();
+                final Iterator<Property<?>> propIterator = ZeroCollidingReferenceStateTable.this.properties.iterator();
                 return new ObjectIterator<>() {
                     @Override
                     public boolean hasNext() {

--- a/src/main/java/ca/spottedleaf/moonrise/patches/blockstate_propertyaccess/util/ZeroCollidingReferenceStateTable.java
+++ b/src/main/java/ca/spottedleaf/moonrise/patches/blockstate_propertyaccess/util/ZeroCollidingReferenceStateTable.java
@@ -170,7 +170,7 @@ public final class ZeroCollidingReferenceStateTable<O, S> {
         return this.properties;
     }
 
-    public Map<Property<?>, Comparable<?>> getMapView(long stateIndex) {
+    public Map<Property<?>, Comparable<?>> getMapView(final long stateIndex) {
         return new MapView(stateIndex);
     }
 
@@ -182,36 +182,36 @@ public final class ZeroCollidingReferenceStateTable<O, S> {
         private final long stateIndex;
         private EntrySet entrySet;
 
-        MapView(long stateIndex) {
+        MapView(final long stateIndex) {
             this.stateIndex = stateIndex;
         }
 
         @Override
-        public boolean containsKey(Object key) {
-            return properties.contains(key);
+        public boolean containsKey(final Object key) {
+            return ZeroCollidingReferenceStateTable.this.properties.contains(key);
         }
 
         @Override
         public int size() {
-            return properties.size();
+            return ZeroCollidingReferenceStateTable.this.properties.size();
         }
 
         @Override
         public ObjectSet<Entry<Property<?>, Comparable<?>>> reference2ObjectEntrySet() {
-            if (entrySet == null)
-                entrySet = new EntrySet();
-            return entrySet;
+            if (this.entrySet == null)
+                this.entrySet = new EntrySet();
+            return this.entrySet;
         }
 
         @Override
-        public Comparable<?> get(Object key) {
-            return key instanceof Property<?> prop ? ZeroCollidingReferenceStateTable.this.get(stateIndex, prop) : null;
+        public Comparable<?> get(final Object key) {
+            return key instanceof Property<?> prop ? ZeroCollidingReferenceStateTable.this.get(this.stateIndex, prop) : null;
         }
 
         class EntrySet extends AbstractObjectSet<Entry<Property<?>, Comparable<?>>> {
             @Override
             public ObjectIterator<Reference2ObjectMap.Entry<Property<?>, Comparable<?>>> iterator() {
-                var propIterator = properties.iterator();
+                Iterator<Property<?>> propIterator = properties.iterator();
                 return new ObjectIterator<>() {
                     @Override
                     public boolean hasNext() {
@@ -220,15 +220,15 @@ public final class ZeroCollidingReferenceStateTable<O, S> {
 
                     @Override
                     public Entry<Property<?>, Comparable<?>> next() {
-                        var prop = propIterator.next();
-                        return new AbstractReference2ObjectMap.BasicEntry<>(prop, ZeroCollidingReferenceStateTable.this.get(stateIndex, prop));
+                        Property<?> prop = propIterator.next();
+                        return new AbstractReference2ObjectMap.BasicEntry<>(prop, ZeroCollidingReferenceStateTable.this.get(MapView.this.stateIndex, prop));
                     }
                 };
             }
 
             @Override
             public int size() {
-                return properties.size();
+                return ZeroCollidingReferenceStateTable.this.properties.size();
             }
         }
     }


### PR DESCRIPTION
Replace last usages of `StateHolder.values` map so we can null it out, saving 150MB or more in larger packs.

This needs a bit of testing with mods in case there are edge cases.