### PR TITLE
Reuse a single ThreadingDetector instance for all PalettedContainers

### DIFF
--- a/src/main/java/ca/spottedleaf/moonrise/mixin/util_threading_detector/PalettedContainerMixin.java
+++ b/src/main/java/ca/spottedleaf/moonrise/mixin/util_threading_detector/PalettedContainerMixin.java
@@ -1,0 +1,29 @@
+package ca.spottedleaf.moonrise.mixin.util_threading_detector;
+
+import net.minecraft.util.ThreadingDetector;
+import net.minecraft.world.level.chunk.PalettedContainer;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Unique;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Redirect;
+
+@Mixin(PalettedContainer.class)
+abstract class PalettedContainerMixin {
+    @Unique
+    private static final ThreadingDetector THREADING_DETECTOR = new ThreadingDetector("PalettedContainer");
+
+    /**
+     * @reason our ThreadingDetectorMixin makes all instance methods no-op, no use in having multiple instances
+     * @author jpenilla
+     */
+    @Redirect(
+        method = "<init>*",
+        at = @At(
+            value = "NEW",
+            target = "Lnet/minecraft/util/ThreadingDetector;"
+        )
+    )
+    private static ThreadingDetector threadingDetector(final String name) {
+        return THREADING_DETECTOR;
+    }
+}

--- a/src/main/resources/moonrise.mixins.json
+++ b/src/main/resources/moonrise.mixins.json
@@ -108,6 +108,7 @@
         "starlight.world.ChunkSerializerMixin",
         "starlight.world.WorldGenRegionMixin",
         "util_thread_counts.UtilMixin",
+        "util_threading_detector.PalettedContainerMixin",
         "util_threading_detector.ThreadingDetectorMixin",
         "util_time_source.UtilMixin"
     ],


### PR DESCRIPTION
We make all instance methods on ThreadingDetector no-op already, so no point in keeping multiple instances around. This saves around 100mb in my ATM10 SP world (with ~5000 chunkholders in memory).