### PR TITLE
Don't call recalcBlockCounts on the client

### DIFF
--- a/src/main/java/ca/spottedleaf/moonrise/mixin/block_counting/LevelChunkSectionMixin.java
+++ b/src/main/java/ca/spottedleaf/moonrise/mixin/block_counting/LevelChunkSectionMixin.java
@@ -60,6 +60,9 @@ abstract class LevelChunkSectionMixin implements BlockCountingChunkSection {
     private int specialCollidingBlocks;
 
     @Unique
+    private boolean client = false;
+
+    @Unique
     private final IntList tickingBlocks = new IntList();
 
     @Override
@@ -87,11 +90,17 @@ abstract class LevelChunkSectionMixin implements BlockCountingChunkSection {
         if (oldState == newState) {
             return;
         }
-        if (CollisionUtil.isSpecialCollidingBlock(oldState)) {
-            --this.specialCollidingBlocks;
-        }
-        if (CollisionUtil.isSpecialCollidingBlock(newState)) {
-            ++this.specialCollidingBlocks;
+        if (!this.client) {
+            if (CollisionUtil.isSpecialCollidingBlock(oldState)) {
+                --this.specialCollidingBlocks;
+            }
+            if (CollisionUtil.isSpecialCollidingBlock(newState)) {
+                ++this.specialCollidingBlocks;
+            }
+        } else {
+            if (CollisionUtil.isSpecialCollidingBlock(newState)) {
+                this.specialCollidingBlocks = 1;
+            }
         }
 
         final int position = x | (z << 4) | (y << (4+4));
@@ -196,5 +205,6 @@ abstract class LevelChunkSectionMixin implements BlockCountingChunkSection {
     )
     private void checkForSpecialCollidingBlocksClient(final CallbackInfo ci) {
         this.specialCollidingBlocks = this.maybeHas(CollisionUtil::isSpecialCollidingBlock) ? 1 : 0;
+        this.client = true;
     }
 }

--- a/src/main/java/ca/spottedleaf/moonrise/mixin/block_counting/LevelChunkSectionMixin.java
+++ b/src/main/java/ca/spottedleaf/moonrise/mixin/block_counting/LevelChunkSectionMixin.java
@@ -55,6 +55,7 @@ abstract class LevelChunkSectionMixin implements BlockCountingChunkSection {
         }
     }
 
+    // Client-side: this will only be 0 or 1 (0 meaning no special colliders, 1 meaning any non-0 amount), see checkForSpecialCollidingBlocksClient and uses of moonrise$getSpecialCollidingBlocks
     @Unique
     private int specialCollidingBlocks;
 
@@ -184,7 +185,7 @@ abstract class LevelChunkSectionMixin implements BlockCountingChunkSection {
     }
 
     /**
-     * @reason Call recalcBlockCounts on the client, as the client does not invoke it when deserializing chunk sections.
+     * @reason We need to know if there are any special colliding blocks in the section
      * @author Spottedleaf
      */
     @Inject(
@@ -193,7 +194,7 @@ abstract class LevelChunkSectionMixin implements BlockCountingChunkSection {
                     value = "RETURN"
             )
     )
-    private void callRecalcBlocksClient(final CallbackInfo ci) {
-        this.recalcBlockCounts();
+    private void checkForSpecialCollidingBlocksClient(final CallbackInfo ci) {
+        this.specialCollidingBlocks = this.maybeHas(CollisionUtil::isSpecialCollidingBlock) ? 1 : 0;
     }
 }


### PR DESCRIPTION
This logic is expensive, and we only need to know if there may be any special colliding blocks in the section.

Before this change, ClientboundLevelChunkWithLightPacket was the top contributor to frame time spikes, after this change it's nowhere near the top of the profile. Specifically, the recalc logic was taking upwards of 80% of the processing time for this packet, the simplified check only takes <5%.

The one downside to this is that when all special colliding blocks are removed from a section with packets other than the ones that resend entire sections, the client will still think there are special colliders until the section is fully resent, which will result in less optimized collisions.