### PR TITLE
Count fluids by their type to avoid unnecessary reads in Entity#updateFluidHeightAndDoFluidPushing

### DIFF
--- a/fabric/src/main/java/ca/spottedleaf/moonrise/fabric/mixin/collisions/EntityMixin.java
+++ b/fabric/src/main/java/ca/spottedleaf/moonrise/fabric/mixin/collisions/EntityMixin.java
@@ -1,8 +1,10 @@
 package ca.spottedleaf.moonrise.fabric.mixin.collisions;
 
+import ca.spottedleaf.moonrise.patches.block_counting.BlockCountingChunkSection;
 import ca.spottedleaf.moonrise.patches.getblock.GetBlockLevel;
 import it.unimi.dsi.fastutil.objects.Object2DoubleMap;
 import net.minecraft.core.BlockPos;
+import net.minecraft.tags.FluidTags;
 import net.minecraft.tags.TagKey;
 import net.minecraft.util.Mth;
 import net.minecraft.world.entity.Entity;
@@ -104,6 +106,21 @@ abstract class EntityMixin {
                     final LevelChunkSection section = sections[sectionIdx];
                     if (section.hasOnlyAir()) {
                         // empty
+                        continue;
+                    }
+
+                    final BlockCountingChunkSection blockCountingSection = (BlockCountingChunkSection)section;
+                    final boolean hasFluids;
+                    if (fluid == FluidTags.WATER) {
+                        hasFluids = blockCountingSection.moonrise$hasWaterFluids();
+                    } else if (fluid == FluidTags.LAVA) {
+                        hasFluids = blockCountingSection.moonrise$hasLavaFluids();
+                    } else {
+                        hasFluids = blockCountingSection.moonrise$hasFluids();
+                    }
+
+                    if (!hasFluids) {
+                        // also empty
                         continue;
                     }
 

--- a/neoforge/src/main/java/ca/spottedleaf/moonrise/neoforge/mixin/collisions/EntityMixin.java
+++ b/neoforge/src/main/java/ca/spottedleaf/moonrise/neoforge/mixin/collisions/EntityMixin.java
@@ -1,6 +1,7 @@
 package ca.spottedleaf.moonrise.neoforge.mixin.collisions;
 
 import ca.spottedleaf.moonrise.neoforge.patches.collisions.FluidPushCalculation;
+import ca.spottedleaf.moonrise.patches.block_counting.BlockCountingChunkSection;
 import ca.spottedleaf.moonrise.patches.getblock.GetBlockLevel;
 import it.unimi.dsi.fastutil.objects.Reference2ReferenceArrayMap;
 import it.unimi.dsi.fastutil.objects.Reference2ReferenceMap;
@@ -98,6 +99,11 @@ abstract class EntityMixin implements IEntityExtension {
                     final LevelChunkSection section = sections[sectionIdx];
                     if (section.hasOnlyAir()) {
                         // empty
+                        continue;
+                    }
+
+                    if (!((BlockCountingChunkSection)section).moonrise$hasFluids()) {
+                        // also empty
                         continue;
                     }
 

--- a/src/main/java/ca/spottedleaf/moonrise/patches/block_counting/BlockCountingChunkSection.java
+++ b/src/main/java/ca/spottedleaf/moonrise/patches/block_counting/BlockCountingChunkSection.java
@@ -8,4 +8,10 @@ public interface BlockCountingChunkSection {
 
     public ShortList moonrise$getTickingBlockList();
 
+    public boolean moonrise$hasFluids();
+
+    public boolean moonrise$hasLavaFluids();
+
+    public boolean moonrise$hasWaterFluids();
+
 }


### PR DESCRIPTION
Avoid searching for chunk sections that don't only have non empty blocks, but also non empty fluids