### PR TITLE
Work on compatibility with porting lib on Fabric

### DIFF
--- a/fabric/src/main/java/ca/spottedleaf/moonrise/fabric/FabricHooks.java
+++ b/fabric/src/main/java/ca/spottedleaf/moonrise/fabric/FabricHooks.java
@@ -29,7 +29,7 @@ import java.util.function.Predicate;
 public final class FabricHooks implements PlatformHooks {
 
     public interface OnExplosionDetonate {
-        void onExplosion(final Level world, final Explosion explosion, final List<Entity> possiblyAffecting, final double diameter);
+        public void onExplosion(final Level world, final Explosion explosion, final List<Entity> possiblyAffecting, final double diameter);
     }
 
     public static final Event<OnExplosionDetonate> ON_EXPLOSION_DETONATE = EventFactory.createArrayBacked(
@@ -37,6 +37,32 @@ public final class FabricHooks implements PlatformHooks {
         listeners -> (final Level world, final Explosion explosion, final List<Entity> possiblyAffecting, final double diameter) -> {
             for (int i = 0; i < listeners.length; i++) {
                 listeners[i].onExplosion(world, explosion, possiblyAffecting, diameter);
+            }
+        }
+    );
+
+    public interface OnChunkWatch {
+        public void onChunkWatch(final ServerLevel world, final LevelChunk chunk, final ServerPlayer player);
+    }
+
+    public static final Event<OnChunkWatch> ON_CHUNK_WATCH = EventFactory.createArrayBacked(
+        OnChunkWatch.class,
+        listeners -> (final ServerLevel world, final LevelChunk chunk, final ServerPlayer player) -> {
+            for (int i = 0; i < listeners.length; i++) {
+                listeners[i].onChunkWatch(world, chunk, player);
+            }
+        }
+    );
+
+    public interface OnChunkUnwatch {
+        public void onChunkUnwatch(final ServerLevel world, final ChunkPos chunk, final ServerPlayer player);
+    }
+
+    public static final Event<OnChunkUnwatch> ON_CHUNK_UNWATCH = EventFactory.createArrayBacked(
+        OnChunkUnwatch.class,
+        listeners -> (final ServerLevel world, final ChunkPos chunk, final ServerPlayer player) -> {
+            for (int i = 0; i < listeners.length; i++) {
+                listeners[i].onChunkUnwatch(world, chunk, player);
             }
         }
     );
@@ -110,12 +136,12 @@ public final class FabricHooks implements PlatformHooks {
 
     @Override
     public void onChunkWatch(final ServerLevel world, final LevelChunk chunk, final ServerPlayer player) {
-
+        ON_CHUNK_WATCH.invoker().onChunkWatch(world, chunk, player);
     }
 
     @Override
     public void onChunkUnWatch(final ServerLevel world, final ChunkPos chunk, final ServerPlayer player) {
-
+        ON_CHUNK_UNWATCH.invoker().onChunkUnwatch(world, chunk, player);
     }
 
     @Override

--- a/fabric/src/main/java/ca/spottedleaf/moonrise/fabric/mixin/chunk_system/FabricLevelMixin.java
+++ b/fabric/src/main/java/ca/spottedleaf/moonrise/fabric/mixin/chunk_system/FabricLevelMixin.java
@@ -1,0 +1,27 @@
+package ca.spottedleaf.moonrise.fabric.mixin.chunk_system;
+
+import net.minecraft.server.level.FullChunkStatus;
+import net.minecraft.world.level.Level;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Redirect;
+
+@Mixin(Level.class)
+abstract class FabricLevelMixin {
+    /**
+     * @reason Allow block updates in non-ticking chunks, as new chunk system sends non-ticking chunks to clients
+     * @author Spottedleaf
+     */
+    @Redirect(
+        method = "setBlock(Lnet/minecraft/core/BlockPos;Lnet/minecraft/world/level/block/state/BlockState;II)Z",
+        at = @At(
+            value = "INVOKE",
+            target = "Lnet/minecraft/server/level/FullChunkStatus;isOrAfter(Lnet/minecraft/server/level/FullChunkStatus;)Z"
+        )
+    )
+    private boolean sendUpdatesForFullChunks(final FullChunkStatus instance,
+        final FullChunkStatus fullChunkStatus) {
+
+        return instance.isOrAfter(FullChunkStatus.FULL);
+    }
+}

--- a/fabric/src/main/resources/moonrise-fabric.mixins.json
+++ b/fabric/src/main/resources/moonrise-fabric.mixins.json
@@ -3,6 +3,7 @@
   "package": "ca.spottedleaf.moonrise.fabric.mixin",
   "mixins": [
     "chunk_system.FabricDistanceManagerMixin",
+    "chunk_system.FabricLevelMixin",
     "chunk_system.FabricMinecraftServerMixin",
     "chunk_system.FabricServerLevelMixin",
     "collisions.EntityMixin"

--- a/neoforge/src/main/java/ca/spottedleaf/moonrise/neoforge/mixin/chunk_system/NeoForgeLevelMixin.java
+++ b/neoforge/src/main/java/ca/spottedleaf/moonrise/neoforge/mixin/chunk_system/NeoForgeLevelMixin.java
@@ -1,0 +1,31 @@
+package ca.spottedleaf.moonrise.neoforge.mixin.chunk_system;
+
+import net.minecraft.server.level.FullChunkStatus;
+import net.minecraft.world.level.Level;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Redirect;
+
+@Mixin(Level.class)
+abstract class NeoForgeLevelMixin {
+    /**
+     * @reason Allow block updates in non-ticking chunks, as new chunk system sends non-ticking chunks to clients
+     * @author Spottedleaf
+     */
+    @Redirect(
+        method = {
+            // "setBlock(Lnet/minecraft/core/BlockPos;Lnet/minecraft/world/level/block/state/BlockState;II)Z",
+            // NeoForge splits logic from the original method into this one
+            "markAndNotifyBlock(Lnet/minecraft/core/BlockPos;Lnet/minecraft/world/level/chunk/LevelChunk;Lnet/minecraft/world/level/block/state/BlockState;Lnet/minecraft/world/level/block/state/BlockState;II)V"
+        },
+        at = @At(
+            value = "INVOKE",
+            target = "Lnet/minecraft/server/level/FullChunkStatus;isOrAfter(Lnet/minecraft/server/level/FullChunkStatus;)Z"
+        )
+    )
+    private boolean sendUpdatesForFullChunks(final FullChunkStatus instance,
+        final FullChunkStatus fullChunkStatus) {
+
+        return instance.isOrAfter(FullChunkStatus.FULL);
+    }
+}

--- a/neoforge/src/main/resources/moonrise-neoforge.mixins.json
+++ b/neoforge/src/main/resources/moonrise-neoforge.mixins.json
@@ -3,6 +3,7 @@
   "package": "ca.spottedleaf.moonrise.neoforge.mixin",
   "mixins": [
     "chunk_system.NeoForgeDistanceManagerMixin",
+    "chunk_system.NeoForgeLevelMixin",
     "chunk_system.NeoForgeMinecraftServerMixin",
     "chunk_system.NeoForgeServerLevelMixin",
     "collisions.EntityMixin"

--- a/src/main/java/ca/spottedleaf/moonrise/mixin/chunk_system/LevelMixin.java
+++ b/src/main/java/ca/spottedleaf/moonrise/mixin/chunk_system/LevelMixin.java
@@ -9,7 +9,6 @@ import ca.spottedleaf.moonrise.patches.chunk_system.level.entity.EntityLookup;
 import ca.spottedleaf.moonrise.patches.chunk_system.level.entity.dfl.DefaultEntityLookup;
 import ca.spottedleaf.moonrise.patches.chunk_system.world.ChunkSystemEntityGetter;
 import net.minecraft.core.BlockPos;
-import net.minecraft.server.level.FullChunkStatus;
 import net.minecraft.util.profiling.ProfilerFiller;
 import net.minecraft.world.entity.Entity;
 import net.minecraft.world.entity.EntityType;
@@ -28,7 +27,6 @@ import org.spongepowered.asm.mixin.Shadow;
 import org.spongepowered.asm.mixin.Unique;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
-import org.spongepowered.asm.mixin.injection.Redirect;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 import java.util.ArrayList;
 import java.util.List;
@@ -301,27 +299,6 @@ abstract class LevelMixin implements ChunkSystemLevel, ChunkSystemEntityGetter, 
     @Override
     public BlockPos getHeightmapPos(Heightmap.Types types, BlockPos blockPos) {
         return new BlockPos(blockPos.getX(), this.getHeight(types, blockPos.getX(), blockPos.getZ()), blockPos.getZ());
-    }
-
-    /**
-     * @reason Allow block updates in non-ticking chunks, as new chunk system sends non-ticking chunks to clients
-     * @author Spottedleaf
-     */
-    @Redirect(
-            method = {
-                    "setBlock(Lnet/minecraft/core/BlockPos;Lnet/minecraft/world/level/block/state/BlockState;II)Z",
-                    // NeoForge splits logic from the original method into this one
-                    "markAndNotifyBlock(Lnet/minecraft/core/BlockPos;Lnet/minecraft/world/level/chunk/LevelChunk;Lnet/minecraft/world/level/block/state/BlockState;Lnet/minecraft/world/level/block/state/BlockState;II)V"
-            },
-            at = @At(
-                    value = "INVOKE",
-                    target = "Lnet/minecraft/server/level/FullChunkStatus;isOrAfter(Lnet/minecraft/server/level/FullChunkStatus;)Z"
-            )
-    )
-    private boolean sendUpdatesForFullChunks(final FullChunkStatus instance,
-                                             final FullChunkStatus fullChunkStatus) {
-
-        return instance.isOrAfter(FullChunkStatus.FULL);
     }
 
     // TODO: Thread.currentThread() != this.thread to TickThread?


### PR DESCRIPTION
- Add events for chunk watch/unwatch
- Split `sendUpdatesForFullChunks` injection into platform-specific mixins to avoid targeting porting lib method using NeoForge method name. This method looks unused, not sure if this is because their 1.21 port is incomplete or if it's just vestigial code. (Hopefully the later since it doesn't look like Mixin will let us inject to their added method)

related: #37, https://github.com/Fabricators-of-Create/Porting-Lib/compare/1.21.1...jpenilla:Porting-Lib:moonrise-compat

The Mixin audit succeeds, but I suspect forced chunks won't tick. Needs further investigation.