### PR TITLE
Use Moonrise executor for section occlusion tasks

### DIFF
--- a/src/main/java/ca/spottedleaf/moonrise/common/util/MoonriseCommon.java
+++ b/src/main/java/ca/spottedleaf/moonrise/common/util/MoonriseCommon.java
@@ -32,6 +32,7 @@ public final class MoonriseCommon {
     public static final long WORKER_QUEUE_HOLD_TIME = (long)(20.0e6); // 20ms
     public static final int CLIENT_DIVISION = 0;
     public static final PrioritisedThreadPool.ExecutorGroup RENDER_EXECUTOR_GROUP = MoonriseCommon.WORKER_POOL.createExecutorGroup(CLIENT_DIVISION, 0);
+    public static final PrioritisedThreadPool.ExecutorGroup SECTION_OCCLUSION_EXECUTOR_GROUP = MoonriseCommon.WORKER_POOL.createExecutorGroup(CLIENT_DIVISION, 0);
     public static final int SERVER_DIVISION = 1;
     public static final PrioritisedThreadPool.ExecutorGroup PARALLEL_GEN_GROUP = MoonriseCommon.WORKER_POOL.createExecutorGroup(SERVER_DIVISION, 0);
     public static final PrioritisedThreadPool.ExecutorGroup RADIUS_AWARE_GROUP = MoonriseCommon.WORKER_POOL.createExecutorGroup(SERVER_DIVISION, 0);

--- a/src/main/java/ca/spottedleaf/moonrise/mixin/render/SectionOcclusionGraphMixin.java
+++ b/src/main/java/ca/spottedleaf/moonrise/mixin/render/SectionOcclusionGraphMixin.java
@@ -1,0 +1,43 @@
+package ca.spottedleaf.moonrise.mixin.render;
+
+import ca.spottedleaf.concurrentutil.executor.thread.PrioritisedThreadPool;
+import ca.spottedleaf.concurrentutil.util.Priority;
+import ca.spottedleaf.moonrise.common.util.MoonriseCommon;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.Executor;
+import net.minecraft.client.renderer.SectionOcclusionGraph;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Unique;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Redirect;
+
+@Mixin(SectionOcclusionGraph.class)
+abstract class SectionOcclusionGraphMixin {
+
+    @Unique
+    private static final PrioritisedThreadPool.ExecutorGroup.ThreadPoolExecutor SECTION_OCCLUSION_EXECUTOR = MoonriseCommon.SECTION_OCCLUSION_EXECUTOR_GROUP.createExecutor(
+        -1, MoonriseCommon.WORKER_QUEUE_HOLD_TIME, 0
+    );
+
+    /**
+     * @reason Change executor to use our thread pool
+     *         Note: even at normal priority, our worker pool will try to share resources equally rather than having it
+     *         be a free-for-all
+     * @author jpenilla
+     */
+    @Redirect(
+        method = "scheduleFullUpdate",
+        at = @At(
+            value = "INVOKE",
+            target = "Ljava/util/concurrent/CompletableFuture;runAsync(Ljava/lang/Runnable;Ljava/util/concurrent/Executor;)Ljava/util/concurrent/CompletableFuture;"
+        )
+    )
+    private CompletableFuture<Void> changeExecutor(final Runnable runnable, final Executor executor) {
+        return CompletableFuture.runAsync(
+            runnable,
+            (final Runnable task) -> {
+                SECTION_OCCLUSION_EXECUTOR.queueTask(task, Priority.NORMAL);
+            }
+        );
+    }
+}

--- a/src/main/java/ca/spottedleaf/moonrise/mixin/render/SectionOcclusionGraphMixin.java
+++ b/src/main/java/ca/spottedleaf/moonrise/mixin/render/SectionOcclusionGraphMixin.java
@@ -50,7 +50,7 @@ abstract class SectionOcclusionGraphMixin {
             } catch (final Throwable throwable) {
                 future.completeExceptionally(throwable);
             }
-        }, Priority.NORMAL);
+        }, Priority.HIGH); // Higher than SectionRenderDispatcherMixin#changeExecutor
         return future;
     }
 }

--- a/src/main/resources/moonrise.mixins.json
+++ b/src/main/resources/moonrise.mixins.json
@@ -128,6 +128,7 @@
     "config.MinecraftMixin",
     "loading_screen.LevelLoadStatusManagerMixin",
     "profiler.MinecraftMixin",
+    "render.SectionOcclusionGraphMixin",
     "render.SectionRenderDispatcherMixin",
     "serverlist.ClientConnectionMixin",
     "serverlist.ServerAddressResolverMixin",


### PR DESCRIPTION
Needs further testing to make sure this is an improvement in terms of frame time spikes.

If we merge this it should be backported to 1.21.1 as well.