### PR TITLE
Add hook for liquid contact

### DIFF
--- a/fabric/src/main/java/ca/spottedleaf/moonrise/fabric/FabricHooks.java
+++ b/fabric/src/main/java/ca/spottedleaf/moonrise/fabric/FabricHooks.java
@@ -15,6 +15,7 @@ import net.minecraft.server.level.ChunkHolder;
 import net.minecraft.server.level.GenerationChunkHolder;
 import net.minecraft.server.level.ServerLevel;
 import net.minecraft.server.level.ServerPlayer;
+import net.minecraft.tags.TagKey;
 import net.minecraft.world.entity.Entity;
 import net.minecraft.world.entity.boss.EnderDragonPart;
 import net.minecraft.world.level.BlockGetter;
@@ -28,6 +29,7 @@ import net.minecraft.world.level.chunk.ProtoChunk;
 import net.minecraft.world.level.chunk.status.ChunkStatusTasks;
 import net.minecraft.world.level.chunk.storage.SerializableChunkData;
 import net.minecraft.world.level.entity.EntityTypeTest;
+import net.minecraft.world.level.material.Fluid;
 import net.minecraft.world.phys.AABB;
 import java.util.Collection;
 import java.util.List;
@@ -254,5 +256,9 @@ public final class FabricHooks extends BaseChunkSystemHooks implements PlatformH
     @Override
     public int modifyEntityTrackingRange(final Entity entity, final int currentRange) {
         return currentRange;
+    }
+
+    @Override
+    public void onFluidContact(final Entity entity, final TagKey<Fluid> fluid, final BlockPos.MutableBlockPos mutablePos) {
     }
 }

--- a/fabric/src/main/java/ca/spottedleaf/moonrise/fabric/mixin/collisions/EntityMixin.java
+++ b/fabric/src/main/java/ca/spottedleaf/moonrise/fabric/mixin/collisions/EntityMixin.java
@@ -1,5 +1,6 @@
 package ca.spottedleaf.moonrise.fabric.mixin.collisions;
 
+import ca.spottedleaf.moonrise.common.PlatformHooks;
 import ca.spottedleaf.moonrise.common.util.WorldUtil;
 import it.unimi.dsi.fastutil.objects.Object2DoubleMap;
 import net.minecraft.core.BlockPos;
@@ -136,6 +137,7 @@ abstract class EntityMixin {
                                 inFluid = true;
                                 maxHeightDiff = Math.max(maxHeightDiff, diff);
 
+                                PlatformHooks.get().onFluidContact((Entity) (Object) this, fluid, mutablePos);
                                 if (!isPushable) {
                                     continue;
                                 }

--- a/neoforge/src/main/java/ca/spottedleaf/moonrise/neoforge/NeoForgeHooks.java
+++ b/neoforge/src/main/java/ca/spottedleaf/moonrise/neoforge/NeoForgeHooks.java
@@ -14,6 +14,7 @@ import net.minecraft.server.level.ChunkHolder;
 import net.minecraft.server.level.GenerationChunkHolder;
 import net.minecraft.server.level.ServerLevel;
 import net.minecraft.server.level.ServerPlayer;
+import net.minecraft.tags.TagKey;
 import net.minecraft.world.entity.Entity;
 import net.minecraft.world.level.BlockGetter;
 import net.minecraft.world.level.ChunkPos;
@@ -27,6 +28,7 @@ import net.minecraft.world.level.chunk.ProtoChunk;
 import net.minecraft.world.level.chunk.status.ChunkStatusTasks;
 import net.minecraft.world.level.chunk.storage.SerializableChunkData;
 import net.minecraft.world.level.entity.EntityTypeTest;
+import net.minecraft.world.level.material.Fluid;
 import net.minecraft.world.phys.AABB;
 import net.neoforged.neoforge.common.CommonHooks;
 import net.neoforged.neoforge.common.NeoForge;
@@ -260,5 +262,9 @@ public final class NeoForgeHooks extends BaseChunkSystemHooks implements Platfor
     @Override
     public int modifyEntityTrackingRange(final Entity entity, final int currentRange) {
         return currentRange;
+    }
+
+    @Override
+    public void onFluidContact(final Entity entity, final TagKey<Fluid> fluid, final BlockPos.MutableBlockPos mutablePos) {
     }
 }

--- a/src/main/java/ca/spottedleaf/moonrise/common/PlatformHooks.java
+++ b/src/main/java/ca/spottedleaf/moonrise/common/PlatformHooks.java
@@ -9,6 +9,7 @@ import net.minecraft.server.level.ChunkHolder;
 import net.minecraft.server.level.GenerationChunkHolder;
 import net.minecraft.server.level.ServerLevel;
 import net.minecraft.server.level.ServerPlayer;
+import net.minecraft.tags.TagKey;
 import net.minecraft.world.entity.Entity;
 import net.minecraft.world.level.BlockGetter;
 import net.minecraft.world.level.ChunkPos;
@@ -19,6 +20,7 @@ import net.minecraft.world.level.chunk.LevelChunk;
 import net.minecraft.world.level.chunk.ProtoChunk;
 import net.minecraft.world.level.chunk.storage.SerializableChunkData;
 import net.minecraft.world.level.entity.EntityTypeTest;
+import net.minecraft.world.level.material.Fluid;
 import net.minecraft.world.phys.AABB;
 import java.util.List;
 import java.util.ServiceLoader;
@@ -101,6 +103,8 @@ public interface PlatformHooks extends ChunkSystemHooks {
     public void postLoadProtoChunk(final ServerLevel world, final ProtoChunk chunk);
 
     public int modifyEntityTrackingRange(final Entity entity, final int currentRange);
+
+    public void onFluidContact(final Entity entity, final TagKey<Fluid> fluid, final BlockPos.MutableBlockPos mutablePos);
 
     public static final class Holder {
         private Holder() {


### PR DESCRIPTION
Needed for PaperMC event call

Should this also be added to forge? 
The issue is the implementation is different where it doesn't have the fluid tag parameter. (I could pass fluid type, but then paper's side would require us to do equality checks on two liquid types now) 