### PR TITLE
Respect autoSaveInterval values less than 1

### DIFF
--- a/src/main/java/ca/spottedleaf/moonrise/patches/chunk_system/scheduling/ChunkHolderManager.java
+++ b/src/main/java/ca/spottedleaf/moonrise/patches/chunk_system/scheduling/ChunkHolderManager.java
@@ -225,7 +225,7 @@ public final class ChunkHolderManager {
     }
 
     void ensureInAutosave(final NewChunkHolder holder) {
-        if (!this.autoSaveQueue.contains(holder)) {
+        if (PlatformHooks.get().configAutoSaveInterval(this.world) > 0 && !this.autoSaveQueue.contains(holder)) {
             holder.lastAutoSave = this.currentTick;
             this.autoSaveQueue.add(holder);
         }


### PR DESCRIPTION
[chunks.auto-save-interval](https://docs.papermc.io/paper/reference/world-configuration#chunks_auto_save_interval) uses 0 to indicate "do not auto save".

When it's negative or default it instead delegates to [ticks-per.autosave](https://docs.papermc.io/paper/reference/bukkit-configuration#ticks_per_autosave) which uses values less than 1 (docs are incorrrect) to indicate "do not auto save"