### PR TITLE
Set chunk loading radius to 0 in PlayerSpawnFinder

### DIFF
--- a/src/main/java/ca/spottedleaf/moonrise/mixin/chunk_system/PlayerSpawnFinderMixin.java
+++ b/src/main/java/ca/spottedleaf/moonrise/mixin/chunk_system/PlayerSpawnFinderMixin.java
@@ -31,7 +31,7 @@ abstract class PlayerSpawnFinderMixin {
         final ChunkPos chunkPos, final int radius) {
 
         return ((ChunkSystemServerLevel)instance.level).moonrise$getChunkTaskScheduler().chunkHolderManager.addTicketAndLoadWithRadius(
-            ticketType, chunkPos, radius, ChunkStatus.FULL, Priority.HIGH
+            ticketType, chunkPos, 0, ChunkStatus.FULL, Priority.HIGH
         );
     }
 }


### PR DESCRIPTION
Matches vanilla behavor, using radius here is wrong.