### PR TITLE
Carpet compatibility

### DIFF
--- a/src/main/java/ca/spottedleaf/moonrise/mixin/collisions/ServerExplosionMixin.java
+++ b/src/main/java/ca/spottedleaf/moonrise/mixin/collisions/ServerExplosionMixin.java
@@ -24,13 +24,11 @@ import net.minecraft.world.phys.Vec3;
 import net.minecraft.world.phys.shapes.VoxelShape;
 import org.spongepowered.asm.mixin.Final;
 import org.spongepowered.asm.mixin.Mixin;
-import org.spongepowered.asm.mixin.Overwrite;
 import org.spongepowered.asm.mixin.Shadow;
 import org.spongepowered.asm.mixin.Unique;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.Redirect;
-import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
 import java.util.Arrays;
 import java.util.List;
@@ -348,8 +346,14 @@ abstract class ServerExplosionMixin {
      * @reason Rewrite ray casting for performance
      * @author Spottedleaf
      */
-    @Overwrite
-    public List<BlockPos> calculateExplodedPositions() {
+    @Inject(
+        method = "calculateExplodedPositions",
+        at = @At(
+            value = "HEAD"
+        ),
+        cancellable = true
+    )
+    public void calculateExplodedPositions(CallbackInfoReturnable<List<BlockPos>> cir) {
         final ObjectArrayList<BlockPos> ret = new ObjectArrayList<>();
 
         final Vec3 center = this.center;
@@ -432,7 +436,7 @@ abstract class ServerExplosionMixin {
             } while (power > 0.0f);
         }
 
-        return ret;
+        cir.setReturnValue(ret);
     }
 
     /**


### PR DESCRIPTION
Closes #141.

Carpet's noBlockDamage mixin is searching for [ExplosionDamageCalculator#getBlockExplosionResistance as injection point](https://github.com/gnembon/fabric-carpet/blob/master/src/main/java/carpet/mixins/Explosion_optimizedTntMixin.java#L72), moonrise [completely overwrites](https://github.com/Tuinity/Moonrise/blob/mc/1.21.10/src/main/java/ca/spottedleaf/moonrise/mixin/collisions/ServerExplosionMixin.java#L352) the `calculateExplodedPositions` method, causing conflict. Using inject and cancel at head will silently disable this injector, but there's another injection point for the noBlockDamage feature [Carpet/Explosion_optimizedTntMixin#L55](https://github.com/gnembon/fabric-carpet/blob/master/src/main/java/carpet/mixins/Explosion_optimizedTntMixin.java#L55), this will clear the affectedBlocks list. So Carpet's feature still works fine.