### PR TITLE
Add config for chunk unload drains per tick

### DIFF
--- a/fabric/src/main/java/ca/spottedleaf/moonrise/fabric/FabricHooks.java
+++ b/fabric/src/main/java/ca/spottedleaf/moonrise/fabric/FabricHooks.java
@@ -223,6 +223,16 @@ public final class FabricHooks extends BaseChunkSystemHooks implements PlatformH
     }
 
     @Override
+    public int configMinUnlockChunksPerTick(final ServerLevel world) {
+        return ConfigHolder.getConfig().chunkSaving.minUnloadChunksPerTick;
+    }
+
+    @Override
+    public double configMaxUnlockChunksPerTickFactor(final ServerLevel world) {
+        return ConfigHolder.getConfig().chunkSaving.maxUnloadChunksPerTickFactor;
+    }
+
+    @Override
     public boolean configFixMC159283() {
         return ConfigHolder.getConfig().bugFixes.fixMC159283;
     }

--- a/neoforge/src/main/java/ca/spottedleaf/moonrise/neoforge/NeoForgeHooks.java
+++ b/neoforge/src/main/java/ca/spottedleaf/moonrise/neoforge/NeoForgeHooks.java
@@ -236,6 +236,16 @@ public final class NeoForgeHooks extends BaseChunkSystemHooks implements Platfor
     }
 
     @Override
+    public int configMinUnlockChunksPerTick(final ServerLevel world) {
+        return ConfigHolder.getConfig().chunkSaving.minUnloadChunksPerTick;
+    }
+
+    @Override
+    public double configMaxUnlockChunksPerTickFactor(final ServerLevel world) {
+        return ConfigHolder.getConfig().chunkSaving.maxUnloadChunksPerTickFactor;
+    }
+
+    @Override
     public boolean configFixMC159283() {
         return ConfigHolder.getConfig().bugFixes.fixMC159283;
     }

--- a/src/main/java/ca/spottedleaf/moonrise/common/PlatformHooks.java
+++ b/src/main/java/ca/spottedleaf/moonrise/common/PlatformHooks.java
@@ -86,6 +86,10 @@ public interface PlatformHooks extends ChunkSystemHooks {
 
     public int configMaxAutoSavePerTick(final ServerLevel world);
 
+    public int configMinUnlockChunksPerTick(final ServerLevel world);
+
+    public double configMaxUnlockChunksPerTickFactor(final ServerLevel world);
+
     public boolean configFixMC159283();
 
     // support for CB chunk mustNotSave

--- a/src/main/java/ca/spottedleaf/moonrise/common/config/moonrise/MoonriseConfig.java
+++ b/src/main/java/ca/spottedleaf/moonrise/common/config/moonrise/MoonriseConfig.java
@@ -147,12 +147,28 @@ public final class MoonriseConfig {
         public Duration autoSaveInterval = Duration.parse("5m");
 
         @Serializable(
-                comment = """
+            comment = """
                         The maximum number of chunks to incrementally autosave each tick. If
                         the value is <= 0, then no chunks will be incrementally saved.
                         """
         )
         public int maxAutoSaveChunksPerTick = 12;
+
+        @Serializable(
+            comment = """
+                        The minimum number of chunks to unload each tick.
+                        See maxUnloadChunksPerTickFactor for more.
+                        """
+        )
+        public int minUnloadChunksPerTick = 50;
+
+        @Serializable(
+            comment = """
+                        The factor to determine maximum unload chunks per tick. The final value is
+                        current pending unload chunks * maxUnloadChunksPerTickFactor .
+                        """
+        )
+        public double maxUnloadChunksPerTickFactor = 0.05;
     }
 
     @Serializable(

--- a/src/main/java/ca/spottedleaf/moonrise/patches/chunk_system/scheduling/ChunkHolderManager.java
+++ b/src/main/java/ca/spottedleaf/moonrise/patches/chunk_system/scheduling/ChunkHolderManager.java
@@ -1155,7 +1155,10 @@ public final class ChunkHolderManager {
         // We do need to process updates here so that any addTicket that is synchronised before this call does not go missed.
         this.processTicketUpdates();
 
-        final int toUnloadCount = Math.max(50, (int)(unloadCountTentative * 0.05));
+        final int toUnloadCount = Math.max(
+            PlatformHooks.get().configMinUnlockChunksPerTick(this.world),
+            (int) (unloadCountTentative * PlatformHooks.get().configMaxUnlockChunksPerTickFactor(this.world))
+        );
         int processedCount = 0;
 
         for (final ChunkUnloadQueue.SectionToUnload sectionRef : unloadSectionsForRegion) {


### PR DESCRIPTION
From my paper server memory dump, I found that the pending unlock chunks takes up most of my memory. I have a lot of players who love to travel around with elytra.

Since there's a `maxAutoSaveChunksPerTick` option, so I think these `UnloadChunksPerTick` options make sense.

After setting `maxUnloadChunksPerTickFactor` to 1.0 on my server, my memory comes very healthy.