### PR TITLE
Match vanilla vertical entity retrieval  in chunk sections

### DIFF
--- a/src/main/java/ca/spottedleaf/moonrise/patches/chunk_system/level/entity/ChunkEntitySlices.java
+++ b/src/main/java/ca/spottedleaf/moonrise/patches/chunk_system/level/entity/ChunkEntitySlices.java
@@ -514,8 +514,9 @@ public final class ChunkEntitySlices {
             final int minSection = this.slices.minSection;
             final int maxSection = this.slices.maxSection;
 
-            final int min = Mth.clamp(Mth.floor(box.minY - 2.0) >> 4, minSection, maxSection);
-            final int max = Mth.clamp(Mth.floor(box.maxY + 2.0) >> 4, minSection, maxSection);
+            // See EntitySectionStorage#forEachAccessibleNonEmptySection
+            final int min = Mth.clamp(Mth.floor(box.minY - 4.0) >> 4, minSection, maxSection);
+            final int max = Mth.clamp(Mth.floor(box.maxY + 0.0) >> 4, minSection, maxSection);
 
             final BasicEntityList<Entity>[] entitiesBySection = this.entitiesBySection;
 
@@ -553,8 +554,9 @@ public final class ChunkEntitySlices {
             final int minSection = this.slices.minSection;
             final int maxSection = this.slices.maxSection;
 
-            final int min = Mth.clamp(Mth.floor(box.minY - 2.0) >> 4, minSection, maxSection);
-            final int max = Mth.clamp(Mth.floor(box.maxY + 2.0) >> 4, minSection, maxSection);
+            // See EntitySectionStorage#forEachAccessibleNonEmptySection
+            final int min = Mth.clamp(Mth.floor(box.minY - 4.0) >> 4, minSection, maxSection);
+            final int max = Mth.clamp(Mth.floor(box.maxY + 0.0) >> 4, minSection, maxSection);
 
             final BasicEntityList<Entity>[] entitiesBySection = this.entitiesBySection;
 


### PR DESCRIPTION
Fixes https://github.com/Tuinity/Moonrise/issues/167

Moonrise was retrieving entities 2 blocks up and down, instead of 4 down 0 up like vanilla does, as described in the original issue.
See https://mcsrc.dev/1/26.2/net/minecraft/world/level/entity/EntitySectionStorage#L37

### How it behaves in Moonrise
Notice the ghast seemingly gets pushed, however it gets pulled back when the client re-syncs, as the piston never pushed the ghast server-side.

https://github.com/user-attachments/assets/5324d98e-dbfd-441c-ad92-356fc1ede110



### How it behaves in Vanilla
Notice the ghast is just pushed, it never gets pulled back

https://github.com/user-attachments/assets/c16afddf-9b0d-46c6-9c97-394395221e00



### How in behaves in Moonrise after this fix
Notice the ghast is now just pushed, like vanilla

https://github.com/user-attachments/assets/8275d099-8773-4aa9-ad5e-17137cd79cb2




