### PR TITLE
Expose loaded chunk holders via MoonriseChunkHolderMap for mod compatibility

### DIFF
--- a/src/main/java/ca/spottedleaf/moonrise/mixin/chunk_system/ChunkMapMixin.java
+++ b/src/main/java/ca/spottedleaf/moonrise/mixin/chunk_system/ChunkMapMixin.java
@@ -6,6 +6,7 @@ import ca.spottedleaf.moonrise.patches.chunk_system.io.MoonriseRegionFileIO;
 import ca.spottedleaf.moonrise.patches.chunk_system.level.ChunkSystemServerLevel;
 import ca.spottedleaf.moonrise.patches.chunk_system.level.chunk.ChunkSystemChunkHolder;
 import ca.spottedleaf.moonrise.patches.chunk_system.player.RegionizedPlayerChunkLoader;
+import ca.spottedleaf.moonrise.patches.chunk_system.scheduling.MoonriseChunkHolderMap;
 import ca.spottedleaf.moonrise.patches.chunk_system.scheduling.NewChunkHolder;
 import com.mojang.datafixers.DataFixer;
 import it.unimi.dsi.fastutil.longs.Long2ObjectLinkedOpenHashMap;
@@ -125,9 +126,10 @@ abstract class ChunkMapMixin extends SimpleRegionStorage implements ChunkHolder.
         LightChunkGetter p_214842_, ChunkGenerator p_214843_,
         ChunkStatusUpdateListener p_214845_, Supplier p_214846_, TicketStorage p_394462_, int p_214847_,
         boolean p_214848_, CallbackInfo ci) {
-        // intentionally destroy old chunk system hooks
-        this.updatingChunkMap = null;
-        this.visibleChunkMap = null;
+        // Expose loaded chunk holders for mod compatibility
+        final MoonriseChunkHolderMap chunkHolderMap = new MoonriseChunkHolderMap(p_214836_);
+        this.updatingChunkMap = chunkHolderMap;
+        this.visibleChunkMap = chunkHolderMap;
         this.pendingUnloads = null;
         this.worldgenTaskDispatcher = null;
         this.lightTaskDispatcher = null;

--- a/src/main/java/ca/spottedleaf/moonrise/patches/chunk_system/scheduling/MoonriseChunkHolderMap.java
+++ b/src/main/java/ca/spottedleaf/moonrise/patches/chunk_system/scheduling/MoonriseChunkHolderMap.java
@@ -1,0 +1,102 @@
+package ca.spottedleaf.moonrise.patches.chunk_system.scheduling;
+
+import ca.spottedleaf.moonrise.patches.chunk_system.level.ChunkSystemServerLevel;
+import it.unimi.dsi.fastutil.longs.Long2ObjectLinkedOpenHashMap;
+import it.unimi.dsi.fastutil.objects.AbstractObjectCollection;
+import it.unimi.dsi.fastutil.objects.ObjectCollection;
+import it.unimi.dsi.fastutil.objects.ObjectIterator;
+import java.util.Iterator;
+import java.util.List;
+import net.minecraft.server.level.ChunkHolder;
+import net.minecraft.server.level.ServerLevel;
+
+/**
+ * A delegating Long2ObjectLinkedOpenHashMap that exposes loaded chunk holders
+ * from Moonrise's ChunkHolderManager to third-party mods which may be
+ * expecting updatingChunkMap/visibleChunkMap to be non-null, matching vanilla.
+ */
+public final class MoonriseChunkHolderMap extends Long2ObjectLinkedOpenHashMap<ChunkHolder> {
+
+    private final ServerLevel level;
+
+    public MoonriseChunkHolderMap(final ServerLevel level) {
+        this.level = level;
+    }
+
+    private ChunkHolderManager getHolderManager() {
+        if (this.level == null) {
+            return null;
+        }
+        return ((ChunkSystemServerLevel) this.level).moonrise$getChunkTaskScheduler().chunkHolderManager;
+    }
+
+    @Override
+    public int size() {
+        final ChunkHolderManager manager = this.getHolderManager();
+        return manager == null ? 0 : manager.size();
+    }
+
+    @Override
+    public boolean isEmpty() {
+        return this.size() == 0;
+    }
+
+    @Override
+    public ChunkHolder get(final long key) {
+        final ChunkHolderManager manager = this.getHolderManager();
+        if (manager == null) {
+            return null;
+        }
+        final NewChunkHolder holder = manager.getChunkHolder(key);
+        return holder == null ? null : holder.vanillaChunkHolder;
+    }
+
+    @Override
+    public ChunkHolder get(final Object key) {
+        if (key instanceof Long longKey) {
+            return this.get(longKey.longValue());
+        }
+        return null;
+    }
+
+    @Override
+    public boolean containsKey(final long key) {
+        return this.get(key) != null;
+    }
+
+    @Override
+    public boolean containsKey(final Object key) {
+        if (key instanceof Long longKey) {
+            return this.containsKey(longKey.longValue());
+        }
+        return false;
+    }
+
+    @Override
+    public ObjectCollection<ChunkHolder> values() {
+        return new AbstractObjectCollection<ChunkHolder>() {
+            @Override
+            public ObjectIterator<ChunkHolder> iterator() {
+                final ChunkHolderManager manager = MoonriseChunkHolderMap.this.getHolderManager();
+                final List<ChunkHolder> holders = manager == null ? List.of() : manager.getOldChunkHolders();
+                final Iterator<ChunkHolder> iterator = holders.iterator();
+                return new ObjectIterator<ChunkHolder>() {
+                    @Override
+                    public boolean hasNext() {
+                        return iterator.hasNext();
+                    }
+
+                    @Override
+                    public ChunkHolder next() {
+                        return iterator.next();
+                    }
+                };
+            }
+
+            @Override
+            public int size() {
+                return MoonriseChunkHolderMap.this.size();
+            }
+        };
+    }
+}


### PR DESCRIPTION
Exposing `updatingChunkMap` and `visibleChunkMap` via a lightweight `MoonriseChunkHolderMap` view for improved mod compatibility, specifically for JourneyMap in my case.

Vanilla `ChunkMap` maintains `updatingChunkMap` and `visibleChunkMap` (`Long2ObjectLinkedOpenHashMap<ChunkHolder>`). JourneyMap accesses `updatingChunkMap` via a Mixin accessor to retrieve loaded chunk holders for rendering on its map. Previously, setting these fields to `null` caused `NullPointerException`s when JourneyMap attempted to iterate over `.values()`. `MoonriseChunkHolderMap` dynamically delegates map operations directly to Moonrise's `ChunkHolderManager` without maintaining a duplicate map in memory.

---
*Generated with Gemini 3.6 Flash via Antigravity CLI.*