### PR TITLE
fix entity tracker iteration during removal

### DIFF
--- a/src/main/java/ca/spottedleaf/moonrise/mixin/entity_tracker/ChunkMapMixin.java
+++ b/src/main/java/ca/spottedleaf/moonrise/mixin/entity_tracker/ChunkMapMixin.java
@@ -1,6 +1,6 @@
 package ca.spottedleaf.moonrise.mixin.entity_tracker;
 
-import ca.spottedleaf.moonrise.common.list.ReferenceList;
+import ca.spottedleaf.moonrise.common.list.IteratorSafeOrderedReferenceSet;
 import ca.spottedleaf.moonrise.common.misc.NearbyPlayers;
 import ca.spottedleaf.moonrise.patches.chunk_system.entity.ChunkSystemEntity;
 import ca.spottedleaf.moonrise.patches.chunk_system.level.ChunkSystemServerLevel;
@@ -70,19 +70,22 @@ abstract class ChunkMapMixin extends SimpleRegionStorage implements ChunkHolder.
     private boolean newTrackerTick(final Iterator<?> iterator) {
         final ServerEntityLookup entityLookup = (ServerEntityLookup)((ChunkSystemServerLevel)this.level).moonrise$getEntityLookup();;
 
-        final ReferenceList<Entity> trackerEntities = entityLookup.trackerEntities;
-        final Entity[] trackerEntitiesRaw = trackerEntities.getRawDataUnchecked();
-        for (int i = 0, len = trackerEntities.size(); i < len; ++i) {
-            final Entity entity = trackerEntitiesRaw[i];
-            final ChunkMap.TrackedEntity tracker = ((EntityTrackerEntity)entity).moonrise$getTrackedEntity();
-            if (tracker == null) {
-                continue;
+        final IteratorSafeOrderedReferenceSet.Iterator<Entity> trackerIterator = entityLookup.trackerEntities.iterator();
+        try {
+            while (trackerIterator.hasNext()) {
+                final Entity entity = trackerIterator.next();
+                final ChunkMap.TrackedEntity tracker = ((EntityTrackerEntity)entity).moonrise$getTrackedEntity();
+                if (tracker == null) {
+                    continue;
+                }
+                ((EntityTrackerTrackedEntity)tracker).moonrise$tick(((ChunkSystemEntity)entity).moonrise$getChunkData().nearbyPlayers);
+                if (((EntityTrackerTrackedEntity)tracker).moonrise$hasPlayers()
+                    || ((ChunkSystemEntity)entity).moonrise$getChunkStatus().isOrAfter(FullChunkStatus.ENTITY_TICKING)) {
+                    tracker.serverEntity.sendChanges();
+                }
             }
-            ((EntityTrackerTrackedEntity)tracker).moonrise$tick(((ChunkSystemEntity)entity).moonrise$getChunkData().nearbyPlayers);
-            if (((EntityTrackerTrackedEntity)tracker).moonrise$hasPlayers()
-                || ((ChunkSystemEntity)entity).moonrise$getChunkStatus().isOrAfter(FullChunkStatus.ENTITY_TICKING)) {
-                tracker.serverEntity.sendChanges();
-            }
+        } finally {
+            trackerIterator.finishedIterating();
         }
 
         return false;

--- a/src/main/java/ca/spottedleaf/moonrise/patches/chunk_system/level/entity/server/ServerEntityLookup.java
+++ b/src/main/java/ca/spottedleaf/moonrise/patches/chunk_system/level/entity/server/ServerEntityLookup.java
@@ -1,7 +1,7 @@
 package ca.spottedleaf.moonrise.patches.chunk_system.level.entity.server;
 
 import ca.spottedleaf.moonrise.common.PlatformHooks;
-import ca.spottedleaf.moonrise.common.list.ReferenceList;
+import ca.spottedleaf.moonrise.common.list.IteratorSafeOrderedReferenceSet;
 import ca.spottedleaf.moonrise.common.util.CoordinateUtils;
 import ca.spottedleaf.moonrise.common.util.TickThread;
 import ca.spottedleaf.moonrise.patches.chunk_system.level.ChunkSystemServerLevel;
@@ -19,10 +19,8 @@ import net.minecraft.world.level.entity.LevelCallback;
 
 public final class ServerEntityLookup extends EntityLookup {
 
-    private static final Entity[] EMPTY_ENTITY_ARRAY = new Entity[0];
-
     private final ServerLevel serverWorld;
-    public final ReferenceList<Entity> trackerEntities = new ReferenceList<>(EMPTY_ENTITY_ARRAY); // Moonrise - entity tracker
+    public final IteratorSafeOrderedReferenceSet<Entity> trackerEntities = new IteratorSafeOrderedReferenceSet<>(Entity.class); // Moonrise - entity tracker
 
     // Vanilla does not increment ticket timeouts if the chunk is progressing in generation. They made this change in 1.21.6 so that the ender pearl
     // ticket does not expire if the chunk fails to generate before the timeout expires. Rather than blindly adjusting the entire system behavior


### PR DESCRIPTION
The entity tracker walks `ReferenceList`'s raw backing array using a cached size. If tracker work removes an entity before the pass completes, `ReferenceList` swap-removes it and clears the old tail. The pass can then reach that null tail or skip an entity moved behind the cursor.

We use the existing `IteratorSafeOrderedReferenceSet` for `trackerEntities` and iterate through its bounded iterator. Removals take effect without compacting storage under the active iterator, while additions wait until the next pass. The iterator state is released in `finally`.

This was reproduced through the synchronous event path reported in https://github.com/PaperMC/Paper/issues/14032.

Paper port: https://github.com/PaperMC/Paper/pull/14122