### PR TITLE
Skip empty random-tick sections

### DIFF
--- a/src/main/java/ca/spottedleaf/moonrise/mixin/block_counting/LevelChunkSectionMixin.java
+++ b/src/main/java/ca/spottedleaf/moonrise/mixin/block_counting/LevelChunkSectionMixin.java
@@ -85,6 +85,12 @@ abstract class LevelChunkSectionMixin implements BlockCountingChunkSection, Rand
         this.moonrise$randomTickIndex = index;
     }
 
+    @Override
+    public final void moonrise$unbindRandomTickChunk() {
+        this.moonrise$randomTickChunk = null;
+        this.moonrise$randomTickIndex = -1;
+    }
+
     @Unique
     private void moonrise$notifyRandomTickIndex(final boolean wasTicking) {
         final boolean nowTicking = this.tickingBlockCount > 0;

--- a/src/main/java/ca/spottedleaf/moonrise/mixin/block_counting/LevelChunkSectionMixin.java
+++ b/src/main/java/ca/spottedleaf/moonrise/mixin/block_counting/LevelChunkSectionMixin.java
@@ -4,12 +4,15 @@ import ca.spottedleaf.moonrise.common.list.ShortList;
 import ca.spottedleaf.moonrise.patches.block_counting.BlockCountingBitStorage;
 import ca.spottedleaf.moonrise.patches.collisions.CollisionUtil;
 import ca.spottedleaf.moonrise.patches.block_counting.BlockCountingChunkSection;
+import ca.spottedleaf.moonrise.patches.random_ticking.RandomTickChunkSection;
+import ca.spottedleaf.moonrise.patches.random_ticking.RandomTickLevelChunk;
 import com.llamalad7.mixinextras.sugar.Local;
 import it.unimi.dsi.fastutil.ints.Int2ObjectMap;
 import it.unimi.dsi.fastutil.ints.Int2ObjectOpenHashMap;
 import it.unimi.dsi.fastutil.shorts.ShortArrayList;
 import net.minecraft.util.BitStorage;
 import net.minecraft.world.level.block.state.BlockState;
+import net.minecraft.world.level.chunk.LevelChunk;
 import net.minecraft.world.level.chunk.LevelChunkSection;
 import net.minecraft.world.level.chunk.Palette;
 import net.minecraft.world.level.chunk.PalettedContainer;
@@ -29,7 +32,7 @@ import java.util.Objects;
 import java.util.function.Predicate;
 
 @Mixin(LevelChunkSection.class)
-abstract class LevelChunkSectionMixin implements BlockCountingChunkSection {
+abstract class LevelChunkSectionMixin implements BlockCountingChunkSection, RandomTickChunkSection {
 
     @Shadow
     @Final
@@ -69,6 +72,26 @@ abstract class LevelChunkSectionMixin implements BlockCountingChunkSection {
 
     @Unique
     private final ShortList tickingBlocks = new ShortList();
+
+    @Unique
+    private RandomTickLevelChunk moonrise$randomTickChunk;
+
+    @Unique
+    private int moonrise$randomTickIndex = -1;
+
+    @Override
+    public final void moonrise$bindRandomTickChunk(final LevelChunk chunk, final int index) {
+        this.moonrise$randomTickChunk = (RandomTickLevelChunk)chunk;
+        this.moonrise$randomTickIndex = index;
+    }
+
+    @Unique
+    private void moonrise$notifyRandomTickIndex(final boolean wasTicking) {
+        final boolean nowTicking = this.tickingBlockCount > 0;
+        if (wasTicking != nowTicking && this.moonrise$randomTickChunk != null) {
+            this.moonrise$randomTickChunk.moonrise$noteRandomTickSection(this.moonrise$randomTickIndex, nowTicking);
+        }
+    }
 
     @Override
     public final boolean moonrise$hasSpecialCollidingBlocks() {
@@ -125,6 +148,17 @@ abstract class LevelChunkSectionMixin implements BlockCountingChunkSection {
                 tickingBlocks.add(position);
             }
         }
+
+        // tickingBlockCount is already updated by vanilla; recover the previous 0/non-zero state.
+        final boolean wasTicking;
+        if (oldTicking == newTicking) {
+            wasTicking = this.tickingBlockCount > 0;
+        } else if (newTicking) {
+            wasTicking = this.tickingBlockCount > 1;
+        } else {
+            wasTicking = true;
+        }
+        this.moonrise$notifyRandomTickIndex(wasTicking);
     }
 
     /**
@@ -134,6 +168,7 @@ abstract class LevelChunkSectionMixin implements BlockCountingChunkSection {
     @Overwrite
     public void recalcBlockCounts() {
         // reset, then recalculate
+        final boolean wasTicking = this.tickingBlockCount > 0;
         this.nonEmptyBlockCount = (short)0;
         this.fluidCount = (short)0;
         this.tickingBlockCount = (short)0;
@@ -196,6 +231,7 @@ abstract class LevelChunkSectionMixin implements BlockCountingChunkSection {
                 }
             }
         }
+        this.moonrise$notifyRandomTickIndex(wasTicking);
     }
 
     /**

--- a/src/main/java/ca/spottedleaf/moonrise/mixin/random_ticking/ChunkAccessMixin.java
+++ b/src/main/java/ca/spottedleaf/moonrise/mixin/random_ticking/ChunkAccessMixin.java
@@ -1,0 +1,46 @@
+package ca.spottedleaf.moonrise.mixin.random_ticking;
+
+import ca.spottedleaf.moonrise.patches.random_ticking.RandomTickLevelChunk;
+import net.minecraft.world.level.chunk.ChunkAccess;
+import net.minecraft.world.level.chunk.LevelChunkSection;
+import org.spongepowered.asm.mixin.Final;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Overwrite;
+import org.spongepowered.asm.mixin.Shadow;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
+
+@Mixin(ChunkAccess.class)
+abstract class ChunkAccessMixin {
+
+    @Shadow
+    @Final
+    protected LevelChunkSection[] sections;
+
+    /**
+     * @reason FAWE/WorldEdit replace sections via {@code getSections()[i] = newSection}.
+     *         Mark the chunk so the next random tick rebinds. Random-tick's own
+     *         getSections is suppressed by begin/end on the chunk.
+     * @author HabsW
+     */
+    @Inject(
+            method = "getSections",
+            at = @At("HEAD")
+    )
+    private void moonrise$noteSectionArrayBorrowed(final CallbackInfoReturnable<LevelChunkSection[]> cir) {
+        if ((Object)this instanceof RandomTickLevelChunk chunk) {
+            chunk.moonrise$noteSectionArrayBorrowed();
+        }
+    }
+
+    /**
+     * @reason Avoid routing {@code getSection} through {@code getSections}, which would
+     *         mark every block lookup as a FAWE-style array borrow.
+     * @author HabsW
+     */
+    @Overwrite
+    public LevelChunkSection getSection(final int sectionIndex) {
+        return this.sections[sectionIndex];
+    }
+}

--- a/src/main/java/ca/spottedleaf/moonrise/mixin/random_ticking/LevelChunkMixin.java
+++ b/src/main/java/ca/spottedleaf/moonrise/mixin/random_ticking/LevelChunkMixin.java
@@ -34,6 +34,9 @@ abstract class LevelChunkMixin extends ChunkAccess implements RandomTickLevelChu
     @Unique
     private int moonrise$randomTickEligibleCount;
 
+    @Unique
+    private LevelChunkSection[] moonrise$boundSectionRefs;
+
     @Override
     public final void moonrise$noteRandomTickSection(final int index, final boolean ticking) {
         final long[] mask = this.moonrise$randomTickSectionMask;
@@ -58,9 +61,33 @@ abstract class LevelChunkMixin extends ChunkAccess implements RandomTickLevelChu
         }
     }
 
+    @Unique
+    private boolean moonrise$sectionRefsChanged(final LevelChunkSection[] sections) {
+        final LevelChunkSection[] bound = this.moonrise$boundSectionRefs;
+        if (bound == null || bound.length != sections.length) {
+            return true;
+        }
+        for (int i = 0; i < sections.length; i++) {
+            if (bound[i] != sections[i]) {
+                return true;
+            }
+        }
+        return false;
+    }
+
     @Override
     public final void moonrise$bindRandomTickSections() {
         final LevelChunkSection[] sections = this.getSections();
+        final LevelChunkSection[] oldRefs = this.moonrise$boundSectionRefs;
+        if (oldRefs != null) {
+            for (int i = 0; i < oldRefs.length; i++) {
+                final LevelChunkSection old = oldRefs[i];
+                if (old != null && (i >= sections.length || old != sections[i])) {
+                    ((RandomTickChunkSection)old).moonrise$unbindRandomTickChunk();
+                }
+            }
+        }
+
         final int words = (sections.length + 63) >> 6;
         if (this.moonrise$randomTickSectionMask == null || this.moonrise$randomTickSectionMask.length != words) {
             this.moonrise$randomTickSectionMask = new long[Math.max(words, 1)];
@@ -76,6 +103,15 @@ abstract class LevelChunkMixin extends ChunkAccess implements RandomTickLevelChu
                     this.moonrise$noteRandomTickSection(i, true);
                 }
             }
+        }
+        this.moonrise$boundSectionRefs = Arrays.copyOf(sections, sections.length);
+    }
+
+    @Override
+    public final void moonrise$ensureRandomTickSections() {
+        final LevelChunkSection[] sections = this.getSections();
+        if (this.moonrise$randomTickSectionMask == null || this.moonrise$sectionRefsChanged(sections)) {
+            this.moonrise$bindRandomTickSections();
         }
     }
 
@@ -103,6 +139,21 @@ abstract class LevelChunkMixin extends ChunkAccess implements RandomTickLevelChu
                                                             final long l, final LevelChunkSection[] levelChunkSections,
                                                             final LevelChunk.PostLoadProcessor postLoadProcessor,
                                                             final BlendingData blendingData, final CallbackInfo ci) {
+        if ((Object)this instanceof EmptyLevelChunk) {
+            return;
+        }
+        this.moonrise$bindRandomTickSections();
+    }
+
+    /**
+     * @reason Post-load processors may replace section objects after the constructor bind.
+     * @author HabsW
+     */
+    @Inject(
+            method = "runPostLoad",
+            at = @At("RETURN")
+    )
+    private void moonrise$bindRandomTickSectionsAfterPostLoad(final CallbackInfo ci) {
         if ((Object)this instanceof EmptyLevelChunk) {
             return;
         }

--- a/src/main/java/ca/spottedleaf/moonrise/mixin/random_ticking/LevelChunkMixin.java
+++ b/src/main/java/ca/spottedleaf/moonrise/mixin/random_ticking/LevelChunkMixin.java
@@ -13,7 +13,9 @@ import net.minecraft.world.level.chunk.PalettedContainerFactory;
 import net.minecraft.world.level.chunk.UpgradeData;
 import net.minecraft.world.level.levelgen.blending.BlendingData;
 import net.minecraft.world.ticks.LevelChunkTicks;
+import org.spongepowered.asm.mixin.Final;
 import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Shadow;
 import org.spongepowered.asm.mixin.Unique;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
@@ -28,6 +30,10 @@ abstract class LevelChunkMixin extends ChunkAccess implements RandomTickLevelChu
         super(chunkPos, upgradeData, levelHeightAccessor, palettedContainerFactory, l, levelChunkSections, blendingData);
     }
 
+    @Shadow
+    @Final
+    protected LevelChunkSection[] sections;
+
     @Unique
     private long[] moonrise$randomTickSectionMask;
 
@@ -36,6 +42,12 @@ abstract class LevelChunkMixin extends ChunkAccess implements RandomTickLevelChu
 
     @Unique
     private LevelChunkSection[] moonrise$boundSectionRefs;
+
+    @Unique
+    private int moonrise$randomTickGetSectionsSuppress;
+
+    @Unique
+    private boolean moonrise$sectionArrayBorrowed;
 
     @Override
     public final void moonrise$noteRandomTickSection(final int index, final boolean ticking) {
@@ -77,7 +89,7 @@ abstract class LevelChunkMixin extends ChunkAccess implements RandomTickLevelChu
 
     @Override
     public final void moonrise$bindRandomTickSections() {
-        final LevelChunkSection[] sections = this.getSections();
+        final LevelChunkSection[] sections = this.sections;
         final LevelChunkSection[] oldRefs = this.moonrise$boundSectionRefs;
         if (oldRefs != null) {
             for (int i = 0; i < oldRefs.length; i++) {
@@ -109,10 +121,36 @@ abstract class LevelChunkMixin extends ChunkAccess implements RandomTickLevelChu
 
     @Override
     public final void moonrise$ensureRandomTickSections() {
-        final LevelChunkSection[] sections = this.getSections();
+        final LevelChunkSection[] sections = this.sections;
         if (this.moonrise$randomTickSectionMask == null || this.moonrise$sectionRefsChanged(sections)) {
             this.moonrise$bindRandomTickSections();
         }
+    }
+
+    @Override
+    public final void moonrise$beginRandomTickGetSections() {
+        this.moonrise$randomTickGetSectionsSuppress++;
+    }
+
+    @Override
+    public final void moonrise$endRandomTickGetSections() {
+        this.moonrise$randomTickGetSectionsSuppress--;
+    }
+
+    @Override
+    public final void moonrise$noteSectionArrayBorrowed() {
+        if (this.moonrise$randomTickGetSectionsSuppress == 0) {
+            this.moonrise$sectionArrayBorrowed = true;
+        }
+    }
+
+    @Override
+    public final boolean moonrise$consumeSectionArrayBorrowed() {
+        if (!this.moonrise$sectionArrayBorrowed) {
+            return false;
+        }
+        this.moonrise$sectionArrayBorrowed = false;
+        return true;
     }
 
     @Override

--- a/src/main/java/ca/spottedleaf/moonrise/mixin/random_ticking/LevelChunkMixin.java
+++ b/src/main/java/ca/spottedleaf/moonrise/mixin/random_ticking/LevelChunkMixin.java
@@ -1,0 +1,111 @@
+package ca.spottedleaf.moonrise.mixin.random_ticking;
+
+import ca.spottedleaf.moonrise.patches.random_ticking.RandomTickChunkSection;
+import ca.spottedleaf.moonrise.patches.random_ticking.RandomTickLevelChunk;
+import net.minecraft.world.level.ChunkPos;
+import net.minecraft.world.level.Level;
+import net.minecraft.world.level.LevelHeightAccessor;
+import net.minecraft.world.level.chunk.ChunkAccess;
+import net.minecraft.world.level.chunk.EmptyLevelChunk;
+import net.minecraft.world.level.chunk.LevelChunk;
+import net.minecraft.world.level.chunk.LevelChunkSection;
+import net.minecraft.world.level.chunk.PalettedContainerFactory;
+import net.minecraft.world.level.chunk.UpgradeData;
+import net.minecraft.world.level.levelgen.blending.BlendingData;
+import net.minecraft.world.ticks.LevelChunkTicks;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Unique;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+import java.util.Arrays;
+
+@Mixin(LevelChunk.class)
+abstract class LevelChunkMixin extends ChunkAccess implements RandomTickLevelChunk {
+
+    public LevelChunkMixin(final ChunkPos chunkPos, final UpgradeData upgradeData, final LevelHeightAccessor levelHeightAccessor,
+                           final PalettedContainerFactory palettedContainerFactory, final long l, final LevelChunkSection[] levelChunkSections, final BlendingData blendingData) {
+        super(chunkPos, upgradeData, levelHeightAccessor, palettedContainerFactory, l, levelChunkSections, blendingData);
+    }
+
+    @Unique
+    private long[] moonrise$randomTickSectionMask;
+
+    @Unique
+    private int moonrise$randomTickEligibleCount;
+
+    @Override
+    public final void moonrise$noteRandomTickSection(final int index, final boolean ticking) {
+        final long[] mask = this.moonrise$randomTickSectionMask;
+        if (mask == null || index < 0) {
+            return;
+        }
+        final int word = index >>> 6;
+        if (word >= mask.length) {
+            return;
+        }
+        final long bit = 1L << (index & 63);
+        final boolean was = (mask[word] & bit) != 0L;
+        if (was == ticking) {
+            return;
+        }
+        if (ticking) {
+            mask[word] |= bit;
+            this.moonrise$randomTickEligibleCount++;
+        } else {
+            mask[word] &= ~bit;
+            this.moonrise$randomTickEligibleCount--;
+        }
+    }
+
+    @Override
+    public final void moonrise$bindRandomTickSections() {
+        final LevelChunkSection[] sections = this.getSections();
+        final int words = (sections.length + 63) >> 6;
+        if (this.moonrise$randomTickSectionMask == null || this.moonrise$randomTickSectionMask.length != words) {
+            this.moonrise$randomTickSectionMask = new long[Math.max(words, 1)];
+        } else {
+            Arrays.fill(this.moonrise$randomTickSectionMask, 0L);
+        }
+        this.moonrise$randomTickEligibleCount = 0;
+        for (int i = 0; i < sections.length; i++) {
+            final LevelChunkSection section = sections[i];
+            if (section != null) {
+                ((RandomTickChunkSection)section).moonrise$bindRandomTickChunk((LevelChunk)(Object)this, i);
+                if (section.isRandomlyTickingBlocks()) {
+                    this.moonrise$noteRandomTickSection(i, true);
+                }
+            }
+        }
+    }
+
+    @Override
+    public final int moonrise$randomTickEligibleCount() {
+        return this.moonrise$randomTickEligibleCount;
+    }
+
+    @Override
+    public final long[] moonrise$randomTickSectionMask() {
+        return this.moonrise$randomTickSectionMask;
+    }
+
+    /**
+     * @reason Bind the live random-tick section bitset after construction.
+     *         Empty chunks are skipped; they are never randomly ticked.
+     * @author HabsW
+     */
+    @Inject(
+            method = "<init>(Lnet/minecraft/world/level/Level;Lnet/minecraft/world/level/ChunkPos;Lnet/minecraft/world/level/chunk/UpgradeData;Lnet/minecraft/world/ticks/LevelChunkTicks;Lnet/minecraft/world/ticks/LevelChunkTicks;J[Lnet/minecraft/world/level/chunk/LevelChunkSection;Lnet/minecraft/world/level/chunk/LevelChunk$PostLoadProcessor;Lnet/minecraft/world/level/levelgen/blending/BlendingData;)V",
+            at = @At("TAIL")
+    )
+    private void moonrise$bindRandomTickSectionsOnConstruct(final Level level, final ChunkPos chunkPos, final UpgradeData upgradeData,
+                                                            final LevelChunkTicks levelChunkTicks, final LevelChunkTicks levelChunkTicks2,
+                                                            final long l, final LevelChunkSection[] levelChunkSections,
+                                                            final LevelChunk.PostLoadProcessor postLoadProcessor,
+                                                            final BlendingData blendingData, final CallbackInfo ci) {
+        if ((Object)this instanceof EmptyLevelChunk) {
+            return;
+        }
+        this.moonrise$bindRandomTickSections();
+    }
+}

--- a/src/main/java/ca/spottedleaf/moonrise/mixin/random_ticking/ServerLevelMixin.java
+++ b/src/main/java/ca/spottedleaf/moonrise/mixin/random_ticking/ServerLevelMixin.java
@@ -87,9 +87,9 @@ abstract class ServerLevelMixin extends Level implements WorldGenLevel {
         // Empty sections never consume random-tick RNG (the inner loop is behind tickingBlockCount > 0).
         // Walk only those sections when sparse; dense chunks keep the original linear scan.
         final RandomTickLevelChunk randomTickChunk = (RandomTickLevelChunk)chunk;
-        if (randomTickChunk.moonrise$randomTickSectionMask() == null) {
-            randomTickChunk.moonrise$bindRandomTickSections();
-        }
+        // Rebuild if never bound, or if a caller replaced LevelChunkSection objects in getSections()
+        // (WorldEdit/FAWE-style). Vanilla has no setSection hook.
+        randomTickChunk.moonrise$ensureRandomTickSections();
         final int eligible = randomTickChunk.moonrise$randomTickEligibleCount();
         if (eligible <= 0) {
             return EMPTY_SECTION_ARRAY;

--- a/src/main/java/ca/spottedleaf/moonrise/mixin/random_ticking/ServerLevelMixin.java
+++ b/src/main/java/ca/spottedleaf/moonrise/mixin/random_ticking/ServerLevelMixin.java
@@ -5,6 +5,7 @@ import ca.spottedleaf.moonrise.common.list.ShortList;
 import ca.spottedleaf.moonrise.common.util.SimpleThreadUnsafeRandom;
 import ca.spottedleaf.moonrise.common.util.WorldUtil;
 import ca.spottedleaf.moonrise.patches.block_counting.BlockCountingChunkSection;
+import ca.spottedleaf.moonrise.patches.random_ticking.RandomTickLevelChunk;
 import com.llamalad7.mixinextras.sugar.Local;
 import net.minecraft.core.BlockPos;
 import net.minecraft.core.Holder;
@@ -58,8 +59,10 @@ abstract class ServerLevelMixin extends Level implements WorldGenLevel {
 
     /**
      * @reason Optimise random ticking so that it will not retrieve BlockStates unnecessarily, as well as
-     *         optionally avoiding double ticking fluid blocks.
+     *         optionally avoiding double ticking fluid blocks. Skip sections with no randomly ticking
+     *         blocks in the outer loop when the chunk is sparse.
      * @author Spottedleaf
+     * @author HabsW
      */
     @Redirect(
             method = "tickChunk",
@@ -79,42 +82,81 @@ abstract class ServerLevelMixin extends Level implements WorldGenLevel {
         final ChunkPos cpos = chunk.getPos();
         final int offsetX = cpos.x() << 4;
         final int offsetZ = cpos.z() << 4;
+        final int sectionsLen = sections.length;
 
-        for (int sectionIndex = 0, sectionsLen = sections.length; sectionIndex < sectionsLen; sectionIndex++) {
-            final int offsetY = (sectionIndex + minSection) << 4;
-            final LevelChunkSection section = sections[sectionIndex];
-            final PalettedContainer<BlockState> states = section.states;
-            if (!section.isRandomlyTickingBlocks()) {
-                continue;
+        // Empty sections never consume random-tick RNG (the inner loop is behind tickingBlockCount > 0).
+        // Walk only those sections when sparse; dense chunks keep the original linear scan.
+        final RandomTickLevelChunk randomTickChunk = (RandomTickLevelChunk)chunk;
+        if (randomTickChunk.moonrise$randomTickSectionMask() == null) {
+            randomTickChunk.moonrise$bindRandomTickSections();
+        }
+        final int eligible = randomTickChunk.moonrise$randomTickEligibleCount();
+        if (eligible <= 0) {
+            return EMPTY_SECTION_ARRAY;
+        }
+        if (eligible * 2 >= sectionsLen) {
+            for (int sectionIndex = 0; sectionIndex < sectionsLen; sectionIndex++) {
+                this.randomTickSection(sections[sectionIndex], sectionIndex, minSection, offsetX, offsetZ, tickSpeed, simpleRandom, doubleTickFluids);
             }
-
-            final ShortList tickList = ((BlockCountingChunkSection)section).moonrise$getTickingBlockList();
-
-            for (int i = 0; i < tickSpeed; ++i) {
-                final int tickingBlocks = tickList.size();
-                final int index = simpleRandom.nextInt() & ((16 * 16 * 16) - 1);
-
-                if (index >= tickingBlocks) {
-                    // most of the time we fall here
+        } else {
+            final long[] mask = randomTickChunk.moonrise$randomTickSectionMask();
+            int from = 0;
+            while (from < sectionsLen) {
+                final int word = from >>> 6;
+                final long bits = mask[word] >>> (from & 63);
+                if (bits != 0L) {
+                    final int sectionIndex = from + Long.numberOfTrailingZeros(bits);
+                    if (sectionIndex >= sectionsLen) {
+                        break;
+                    }
+                    this.randomTickSection(sections[sectionIndex], sectionIndex, minSection, offsetX, offsetZ, tickSpeed, simpleRandom, doubleTickFluids);
+                    from = sectionIndex + 1;
                     continue;
                 }
-
-                final int location = (int)tickList.getRaw(index) & 0xFFFF;
-                final BlockState state = states.get(location);
-
-                // do not use a mutable pos, as some random tick implementations store the input without calling immutable()!
-                final BlockPos pos = new BlockPos((location & 15) | offsetX, ((location >>> (4 + 4)) & 15) | offsetY, ((location >>> 4) & 15) | offsetZ);
-
-                state.randomTick((ServerLevel)(Object)this, pos, simpleRandom);
-                if (doubleTickFluids) {
-                    final FluidState fluidState = state.getFluidState();
-                    if (fluidState.isRandomlyTicking()) {
-                        fluidState.randomTick((ServerLevel)(Object)this, pos, simpleRandom);
-                    }
-                }
+                from = (word + 1) << 6;
             }
         }
 
         return EMPTY_SECTION_ARRAY;
+    }
+
+    /**
+     * @reason Inner random-tick work for one section. Unchanged vs the original ShortList selection.
+     * @author HabsW
+     */
+    @Unique
+    private void randomTickSection(final LevelChunkSection section, final int sectionIndex, final int minSection,
+                                   final int offsetX, final int offsetZ, final int tickSpeed,
+                                   final SimpleThreadUnsafeRandom simpleRandom, final boolean doubleTickFluids) {
+        if (!section.isRandomlyTickingBlocks()) {
+            return;
+        }
+        final int offsetY = (sectionIndex + minSection) << 4;
+        final PalettedContainer<BlockState> states = section.states;
+        final ShortList tickList = ((BlockCountingChunkSection)section).moonrise$getTickingBlockList();
+
+        for (int i = 0; i < tickSpeed; ++i) {
+            final int tickingBlocks = tickList.size();
+            final int index = simpleRandom.nextInt() & ((16 * 16 * 16) - 1);
+
+            if (index >= tickingBlocks) {
+                // most of the time we fall here
+                continue;
+            }
+
+            final int location = (int)tickList.getRaw(index) & 0xFFFF;
+            final BlockState state = states.get(location);
+
+            // do not use a mutable pos, as some random tick implementations store the input without calling immutable()!
+            final BlockPos pos = new BlockPos((location & 15) | offsetX, ((location >>> (4 + 4)) & 15) | offsetY, ((location >>> 4) & 15) | offsetZ);
+
+            state.randomTick((ServerLevel)(Object)this, pos, simpleRandom);
+            if (doubleTickFluids) {
+                final FluidState fluidState = state.getFluidState();
+                if (fluidState.isRandomlyTicking()) {
+                    fluidState.randomTick((ServerLevel)(Object)this, pos, simpleRandom);
+                }
+            }
+        }
     }
 }

--- a/src/main/java/ca/spottedleaf/moonrise/mixin/random_ticking/ServerLevelMixin.java
+++ b/src/main/java/ca/spottedleaf/moonrise/mixin/random_ticking/ServerLevelMixin.java
@@ -74,7 +74,13 @@ abstract class ServerLevelMixin extends Level implements WorldGenLevel {
     )
     private LevelChunkSection[] optimiseRandomTick(final LevelChunk chunk,
                                                    @Local(ordinal = 0, argsOnly = true) final int tickSpeed) {
+        final RandomTickLevelChunk randomTickChunk = (RandomTickLevelChunk)chunk;
+        randomTickChunk.moonrise$beginRandomTickGetSections();
         final LevelChunkSection[] sections = chunk.getSections();
+        randomTickChunk.moonrise$endRandomTickGetSections();
+        if (randomTickChunk.moonrise$randomTickSectionMask() == null || randomTickChunk.moonrise$consumeSectionArrayBorrowed()) {
+            randomTickChunk.moonrise$ensureRandomTickSections();
+        }
         final int minSection = WorldUtil.getMinSection((ServerLevel)(Object)this);
         final SimpleThreadUnsafeRandom simpleRandom = this.simpleRandom;
         final boolean doubleTickFluids = !PlatformHooks.get().configFixMC224294();
@@ -86,10 +92,6 @@ abstract class ServerLevelMixin extends Level implements WorldGenLevel {
 
         // Empty sections never consume random-tick RNG (the inner loop is behind tickingBlockCount > 0).
         // Walk only those sections when sparse; dense chunks keep the original linear scan.
-        final RandomTickLevelChunk randomTickChunk = (RandomTickLevelChunk)chunk;
-        // Rebuild if never bound, or if a caller replaced LevelChunkSection objects in getSections()
-        // (WorldEdit/FAWE-style). Vanilla has no setSection hook.
-        randomTickChunk.moonrise$ensureRandomTickSections();
         final int eligible = randomTickChunk.moonrise$randomTickEligibleCount();
         if (eligible <= 0) {
             return EMPTY_SECTION_ARRAY;

--- a/src/main/java/ca/spottedleaf/moonrise/patches/random_ticking/RandomTickChunkSection.java
+++ b/src/main/java/ca/spottedleaf/moonrise/patches/random_ticking/RandomTickChunkSection.java
@@ -1,0 +1,9 @@
+package ca.spottedleaf.moonrise.patches.random_ticking;
+
+import net.minecraft.world.level.chunk.LevelChunk;
+
+public interface RandomTickChunkSection {
+
+    public void moonrise$bindRandomTickChunk(final LevelChunk chunk, final int index);
+
+}

--- a/src/main/java/ca/spottedleaf/moonrise/patches/random_ticking/RandomTickChunkSection.java
+++ b/src/main/java/ca/spottedleaf/moonrise/patches/random_ticking/RandomTickChunkSection.java
@@ -6,4 +6,6 @@ public interface RandomTickChunkSection {
 
     public void moonrise$bindRandomTickChunk(final LevelChunk chunk, final int index);
 
+    public void moonrise$unbindRandomTickChunk();
+
 }

--- a/src/main/java/ca/spottedleaf/moonrise/patches/random_ticking/RandomTickLevelChunk.java
+++ b/src/main/java/ca/spottedleaf/moonrise/patches/random_ticking/RandomTickLevelChunk.java
@@ -6,6 +6,8 @@ public interface RandomTickLevelChunk {
 
     public void moonrise$bindRandomTickSections();
 
+    public void moonrise$ensureRandomTickSections();
+
     public int moonrise$randomTickEligibleCount();
 
     public long[] moonrise$randomTickSectionMask();

--- a/src/main/java/ca/spottedleaf/moonrise/patches/random_ticking/RandomTickLevelChunk.java
+++ b/src/main/java/ca/spottedleaf/moonrise/patches/random_ticking/RandomTickLevelChunk.java
@@ -8,6 +8,14 @@ public interface RandomTickLevelChunk {
 
     public void moonrise$ensureRandomTickSections();
 
+    public void moonrise$beginRandomTickGetSections();
+
+    public void moonrise$endRandomTickGetSections();
+
+    public void moonrise$noteSectionArrayBorrowed();
+
+    public boolean moonrise$consumeSectionArrayBorrowed();
+
     public int moonrise$randomTickEligibleCount();
 
     public long[] moonrise$randomTickSectionMask();

--- a/src/main/java/ca/spottedleaf/moonrise/patches/random_ticking/RandomTickLevelChunk.java
+++ b/src/main/java/ca/spottedleaf/moonrise/patches/random_ticking/RandomTickLevelChunk.java
@@ -1,0 +1,13 @@
+package ca.spottedleaf.moonrise.patches.random_ticking;
+
+public interface RandomTickLevelChunk {
+
+    public void moonrise$noteRandomTickSection(final int index, final boolean ticking);
+
+    public void moonrise$bindRandomTickSections();
+
+    public int moonrise$randomTickEligibleCount();
+
+    public long[] moonrise$randomTickSectionMask();
+
+}

--- a/src/main/resources/moonrise.mixins.json
+++ b/src/main/resources/moonrise.mixins.json
@@ -112,6 +112,7 @@
         "random.LevelMixin",
         "random_ticking.BiomeManagerMixin",
         "random_ticking.BiomeMixin",
+        "random_ticking.LevelChunkMixin",
         "random_ticking.LevelMixin",
         "random_ticking.ServerLevelMixin",
         "serverlist.ConnectionMixin",

--- a/src/main/resources/moonrise.mixins.json
+++ b/src/main/resources/moonrise.mixins.json
@@ -112,6 +112,7 @@
         "random.LevelMixin",
         "random_ticking.BiomeManagerMixin",
         "random_ticking.BiomeMixin",
+        "random_ticking.ChunkAccessMixin",
         "random_ticking.LevelChunkMixin",
         "random_ticking.LevelMixin",
         "random_ticking.ServerLevelMixin",


### PR DESCRIPTION
Moonrise already skips the inner random-tick work when a section has no ticking blocks, but the outer loop still walks every section sequentially.

This change keeps a lightweight per-chunk bitset of sections with `tickingBlockCount > 0`. Sparse chunks only visit sections with active ticking blocks (in the exact same section index order as before), while dense chunks retain the original linear scan. Because empty sections never consumed random-tick RNG, skipping them maintains identical game timing and behavior. The mask is built on load, updated on 0/non-zero transitions, and rebound on the next random tick if a plugin replaces a section object through `getSections()` (WorldEdit/FAWE).

### Benchmarks (`optimiseRandomTick` isolated)
*Note: These metrics measure duration inside `optimiseRandomTick` only, **not** overall server MSPT.*

Measured across 1,024 forceloaded chunks (`random_tick_speed=3`) on a Ryzen 9 9950X3D / JDK 25:

* **Normal Overworld:** No change (613 µs → 614 µs)
* **Superflat World:** 422 µs → 387 µs (**1.09x**)
* **Skyblock (Void + Grass):** 231 µs → 121 µs (**1.90x**)
* **The End (Main Island):** 234 µs → 115 µs (**2.04x**)

---

### Reproduction & Reference
* **Detailed Benchmarks:** Machine, world settings, and equivalence results are documented in [`docs/TEST.md`](https://github.com/HabsW/ConfluenceMC/blob/feature/ssti-prototype/docs/TEST.md).
* **Reference Prototype Patch:** View the standalone Paper patch [`0001-Skip-empty-random-tick-sections.patch`](https://github.com/HabsW/ConfluenceMC/blob/feature/ssti-prototype/patches/0001-Skip-empty-random-tick-sections.patch).