### PR TITLE
Optimize retained VoxelShape memory usage

### DIFF
--- a/src/main/java/ca/spottedleaf/moonrise/common/util/VoxelShapeInternPool.java
+++ b/src/main/java/ca/spottedleaf/moonrise/common/util/VoxelShapeInternPool.java
@@ -1,0 +1,284 @@
+package ca.spottedleaf.moonrise.common.util;
+
+import ca.spottedleaf.moonrise.patches.collisions.shape.CachedShapeData;
+import ca.spottedleaf.moonrise.patches.collisions.shape.CollisionDiscreteVoxelShape;
+import it.unimi.dsi.fastutil.Hash;
+import it.unimi.dsi.fastutil.doubles.DoubleArrayList;
+import it.unimi.dsi.fastutil.doubles.DoubleList;
+import it.unimi.dsi.fastutil.objects.Reference2ObjectOpenHashMap;
+import it.unimi.dsi.fastutil.objects.ObjectOpenCustomHashSet;
+import net.minecraft.world.phys.AABB;
+import net.minecraft.world.phys.shapes.BitSetDiscreteVoxelShape;
+import net.minecraft.world.phys.shapes.DiscreteVoxelShape;
+import java.util.Arrays;
+
+/**
+ * Interns reusable geometry retained by VoxelShape collision caches.
+ * Geometry shared here is treated as immutable after VoxelShape construction.
+ * Pools are bounded because their entries live for the lifetime of the process.
+ */
+public final class VoxelShapeInternPool {
+
+    private static final int MAX_COORDINATE_PATTERNS = 4096;
+    private static final int MAX_COORDINATE_LIST_SIZE = 32;
+
+    // Global interning is for reusable block-local geometry. World-space geometry has
+    // high-cardinality coordinates and should bypass hashing/locking. This only controls whether
+    // an object is shared; values outside this range keep their normal behaviour.
+    private static final double MAX_ABSOLUTE_LOCAL_COORDINATE = 16.0;
+
+    private static final int MAX_SHAPE_PATTERNS = 8192;
+    // 64 words cover a 16x16x16 voxel grid. Larger shapes are not retained globally.
+    private static final int MAX_VOXEL_SET_WORDS = 64;
+
+    private static final int MAX_AABB_PATTERNS = MAX_SHAPE_PATTERNS * 2;
+
+    private static final Hash.Strategy<DoubleArrayList> COORDINATE_LIST_STRATEGY = new Hash.Strategy<>() {
+        @Override
+        public int hashCode(final DoubleArrayList list) {
+            if (list == null) {
+                return 0;
+            }
+
+            int hash = 1;
+            for (int i = 0, len = list.size(); i < len; ++i) {
+                hash = 31 * hash + Double.hashCode(list.getDouble(i));
+            }
+            return hash;
+        }
+
+        @Override
+        public boolean equals(final DoubleArrayList first, final DoubleArrayList second) {
+            if (first == second) {
+                return true;
+            }
+            if (first == null || second == null || first.size() != second.size()) {
+                return false;
+            }
+
+            for (int i = 0, len = first.size(); i < len; ++i) {
+                if (Double.doubleToLongBits(first.getDouble(i)) != Double.doubleToLongBits(second.getDouble(i))) {
+                    return false;
+                }
+            }
+            return true;
+        }
+    };
+
+    private static final Hash.Strategy<CachedShapeData> SHAPE_DATA_STRATEGY = new Hash.Strategy<>() {
+        @Override
+        public int hashCode(final CachedShapeData data) {
+            if (data == null) {
+                return 0;
+            }
+
+            int hash = Arrays.hashCode(data.voxelSet());
+            hash = 31 * hash + data.sizeX();
+            hash = 31 * hash + data.sizeY();
+            hash = 31 * hash + data.sizeZ();
+            hash = 31 * hash + data.minFullX();
+            hash = 31 * hash + data.minFullY();
+            hash = 31 * hash + data.minFullZ();
+            hash = 31 * hash + data.maxFullX();
+            hash = 31 * hash + data.maxFullY();
+            hash = 31 * hash + data.maxFullZ();
+            hash = 31 * hash + (data.isEmpty() ? 1 : 0);
+            hash = 31 * hash + (data.hasSingleAABB() ? 1 : 0);
+            return hash;
+        }
+
+        @Override
+        public boolean equals(final CachedShapeData first, final CachedShapeData second) {
+            if (first == second) {
+                return true;
+            }
+            if (first == null || second == null) {
+                return false;
+            }
+
+            return first.sizeX() == second.sizeX()
+                    && first.sizeY() == second.sizeY()
+                    && first.sizeZ() == second.sizeZ()
+                    && first.minFullX() == second.minFullX()
+                    && first.minFullY() == second.minFullY()
+                    && first.minFullZ() == second.minFullZ()
+                    && first.maxFullX() == second.maxFullX()
+                    && first.maxFullY() == second.maxFullY()
+                    && first.maxFullZ() == second.maxFullZ()
+                    && first.isEmpty() == second.isEmpty()
+                    && first.hasSingleAABB() == second.hasSingleAABB()
+                    && Arrays.equals(first.voxelSet(), second.voxelSet());
+        }
+    };
+
+    private static final Hash.Strategy<AABB> AABB_STRATEGY = new Hash.Strategy<>() {
+        @Override
+        public int hashCode(final AABB box) {
+            if (box == null) {
+                return 0;
+            }
+
+            int hash = Long.hashCode(Double.doubleToLongBits(box.minX));
+            hash = 31 * hash + Long.hashCode(Double.doubleToLongBits(box.minY));
+            hash = 31 * hash + Long.hashCode(Double.doubleToLongBits(box.minZ));
+            hash = 31 * hash + Long.hashCode(Double.doubleToLongBits(box.maxX));
+            hash = 31 * hash + Long.hashCode(Double.doubleToLongBits(box.maxY));
+            hash = 31 * hash + Long.hashCode(Double.doubleToLongBits(box.maxZ));
+            return hash;
+        }
+
+        @Override
+        public boolean equals(final AABB first, final AABB second) {
+            if (first == second) {
+                return true;
+            }
+            if (first == null || second == null) {
+                return false;
+            }
+
+            return Double.doubleToLongBits(first.minX) == Double.doubleToLongBits(second.minX)
+                    && Double.doubleToLongBits(first.minY) == Double.doubleToLongBits(second.minY)
+                    && Double.doubleToLongBits(first.minZ) == Double.doubleToLongBits(second.minZ)
+                    && Double.doubleToLongBits(first.maxX) == Double.doubleToLongBits(second.maxX)
+                    && Double.doubleToLongBits(first.maxY) == Double.doubleToLongBits(second.maxY)
+                    && Double.doubleToLongBits(first.maxZ) == Double.doubleToLongBits(second.maxZ);
+        }
+    };
+
+    private static final ObjectOpenCustomHashSet<DoubleArrayList> COORDINATE_LISTS =
+        new ObjectOpenCustomHashSet<>(COORDINATE_LIST_STRATEGY);
+
+    private static final ObjectOpenCustomHashSet<CachedShapeData> SHAPE_DATA =
+        new ObjectOpenCustomHashSet<>(SHAPE_DATA_STRATEGY);
+
+    // Eligible CachedShapeData is canonical before it reaches this map, so identity is sufficient
+    // and avoids hashing the voxel array a second time during DiscreteVoxelShape interning.
+    private static final Reference2ObjectOpenHashMap<CachedShapeData, DiscreteVoxelShape> DISCRETE_SHAPES =
+        new Reference2ObjectOpenHashMap<>();
+
+    private static final ObjectOpenCustomHashSet<AABB> AABBS =
+        new ObjectOpenCustomHashSet<>(AABB_STRATEGY);
+
+    private VoxelShapeInternPool() {}
+
+    private static boolean isOutsideLocalInterningRange(final double value) {
+        return !Double.isFinite(value) || Math.abs(value) > MAX_ABSOLUTE_LOCAL_COORDINATE;
+    }
+
+    private static boolean hasOutOfRangeCoordinates(final DoubleArrayList list) {
+        for (int i = 0, len = list.size(); i < len; ++i) {
+            if (isOutsideLocalInterningRange(list.getDouble(i))) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    private static boolean hasOutOfRangeCoordinates(final AABB box) {
+        return isOutsideLocalInterningRange(box.minX)
+            || isOutsideLocalInterningRange(box.minY)
+            || isOutsideLocalInterningRange(box.minZ)
+            || isOutsideLocalInterningRange(box.maxX)
+            || isOutsideLocalInterningRange(box.maxY)
+            || isOutsideLocalInterningRange(box.maxZ);
+    }
+
+    private static boolean canInternCoordinateList(final DoubleList list) {
+        if (list == null || list.getClass() != DoubleArrayList.class) {
+            return false;
+        }
+
+        final DoubleArrayList rawList = (DoubleArrayList)list;
+        final int size = rawList.size();
+        return size > 0 && size <= MAX_COORDINATE_LIST_SIZE && !hasOutOfRangeCoordinates(rawList);
+    }
+
+    public static DoubleList internCoordinateList(final DoubleList list) {
+        if (!canInternCoordinateList(list)) {
+            return list;
+        }
+
+        final DoubleArrayList rawList = (DoubleArrayList)list;
+        final int size = rawList.size();
+
+        synchronized (COORDINATE_LISTS) {
+            final DoubleArrayList existing = COORDINATE_LISTS.get(rawList);
+            if (existing != null) {
+                return existing;
+            }
+            if (COORDINATE_LISTS.size() >= MAX_COORDINATE_PATTERNS) {
+                return list;
+            }
+
+            // Only allocate a trimmed backing array for a value that will actually be retained.
+            final double[] raw = rawList.elements();
+            final DoubleArrayList candidate = raw.length == size
+                ? rawList
+                : DoubleArrayList.wrap(Arrays.copyOf(raw, size));
+            COORDINATE_LISTS.add(candidate);
+            return candidate;
+        }
+    }
+
+    public static CachedShapeData internShapeData(final CachedShapeData data) {
+        if (exceedsShapeInterningLimit(data)) {
+            return data;
+        }
+
+        synchronized (SHAPE_DATA) {
+            if (SHAPE_DATA.size() >= MAX_SHAPE_PATTERNS) {
+                final CachedShapeData existing = SHAPE_DATA.get(data);
+                return existing != null ? existing : data;
+            }
+
+            return SHAPE_DATA.addOrGet(data);
+        }
+    }
+
+    public static DiscreteVoxelShape internDiscreteShape(final DiscreteVoxelShape shape) {
+        // A subclass may contain state which is not represented by CachedShapeData.
+        if (shape == null || shape.getClass() != BitSetDiscreteVoxelShape.class) {
+            return shape;
+        }
+
+        // Mixin adds CollisionDiscreteVoxelShape to DiscreteVoxelShape at runtime.
+        final CachedShapeData data = ((CollisionDiscreteVoxelShape)(Object)shape).moonrise$getOrCreateCachedShapeData(true);
+        if (exceedsShapeInterningLimit(data)) {
+            return shape;
+        }
+
+        synchronized (DISCRETE_SHAPES) {
+            final DiscreteVoxelShape existing = DISCRETE_SHAPES.get(data);
+            if (existing != null) {
+                return existing;
+            }
+
+            if (DISCRETE_SHAPES.size() >= MAX_SHAPE_PATTERNS) {
+                return shape;
+            }
+
+            DISCRETE_SHAPES.put(data, shape);
+            return shape;
+        }
+    }
+
+    public static AABB internAABB(final AABB box) {
+        // Reject high-cardinality world-space values before hashing or taking the pool lock.
+        if (hasOutOfRangeCoordinates(box)) {
+            return box;
+        }
+
+        synchronized (AABBS) {
+            if (AABBS.size() >= MAX_AABB_PATTERNS) {
+                final AABB existing = AABBS.get(box);
+                return existing != null ? existing : box;
+            }
+
+            return AABBS.addOrGet(box);
+        }
+    }
+
+    private static boolean exceedsShapeInterningLimit(final CachedShapeData data) {
+        return data.voxelSet().length > MAX_VOXEL_SET_WORDS;
+    }
+}

--- a/src/main/java/ca/spottedleaf/moonrise/mixin/collisions/ArrayVoxelShapeMixin.java
+++ b/src/main/java/ca/spottedleaf/moonrise/mixin/collisions/ArrayVoxelShapeMixin.java
@@ -1,19 +1,39 @@
 package ca.spottedleaf.moonrise.mixin.collisions;
 
+import ca.spottedleaf.moonrise.common.util.VoxelShapeInternPool;
+import ca.spottedleaf.moonrise.patches.collisions.shape.CollisionArrayVoxelShape;
 import ca.spottedleaf.moonrise.patches.collisions.shape.CollisionVoxelShape;
 import it.unimi.dsi.fastutil.doubles.DoubleList;
 import net.minecraft.world.phys.shapes.ArrayVoxelShape;
 import net.minecraft.world.phys.shapes.DiscreteVoxelShape;
+import org.spongepowered.asm.mixin.Final;
 import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Mutable;
+import org.spongepowered.asm.mixin.Shadow;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 
 @Mixin(ArrayVoxelShape.class)
-abstract class ArrayVoxelShapeMixin {
+abstract class ArrayVoxelShapeMixin implements CollisionArrayVoxelShape {
+
+    @Shadow(aliases = "xPoints")
+    @Final
+    @Mutable
+    private DoubleList xs;
+
+    @Shadow(aliases = "yPoints")
+    @Final
+    @Mutable
+    private DoubleList ys;
+
+    @Shadow(aliases = "zPoints")
+    @Final
+    @Mutable
+    private DoubleList zs;
 
     /**
-     * @reason Hook into the root constructor to pass along init data to superclass.
+     * @reason Initialise collision caches without interning transient geometry.
      * @author Spottedleaf
      */
     @Inject(
@@ -25,6 +45,15 @@ abstract class ArrayVoxelShapeMixin {
     private void initState(final DiscreteVoxelShape discreteVoxelShape,
                            final DoubleList xList, final DoubleList yList, final DoubleList zList,
                            final CallbackInfo ci) {
+        // Generic construction can be runtime/transient (entity AABBs, joins, moves).
+        // Retained interning is performed later only if a BlockState cache keeps this shape.
         ((CollisionVoxelShape)this).moonrise$initCache();
+    }
+
+    @Override
+    public final void moonrise$internRetainedCoordinates() {
+        this.xs = VoxelShapeInternPool.internCoordinateList(this.xs);
+        this.ys = VoxelShapeInternPool.internCoordinateList(this.ys);
+        this.zs = VoxelShapeInternPool.internCoordinateList(this.zs);
     }
 }

--- a/src/main/java/ca/spottedleaf/moonrise/mixin/collisions/BlockStateBaseMixin.java
+++ b/src/main/java/ca/spottedleaf/moonrise/mixin/collisions/BlockStateBaseMixin.java
@@ -68,6 +68,8 @@ abstract class BlockStateBaseMixin extends StateHolder<Block, BlockState> implem
 
     @Unique
     private static void initCaches(final VoxelShape shape, final boolean neighbours) {
+        // This shape is now owned by a long-lived BlockState cache.
+        ((CollisionVoxelShape)shape).moonrise$promoteRetainedGeometry();
         ((CollisionVoxelShape)shape).moonrise$isFullBlock();
         ((CollisionVoxelShape)shape).moonrise$occludesFullBlock();
         shape.toAabbs();

--- a/src/main/java/ca/spottedleaf/moonrise/mixin/collisions/DiscreteVoxelShapeMixin.java
+++ b/src/main/java/ca/spottedleaf/moonrise/mixin/collisions/DiscreteVoxelShapeMixin.java
@@ -1,5 +1,6 @@
 package ca.spottedleaf.moonrise.mixin.collisions;
 
+import ca.spottedleaf.moonrise.common.util.VoxelShapeInternPool;
 import ca.spottedleaf.moonrise.patches.collisions.shape.CachedShapeData;
 import ca.spottedleaf.moonrise.patches.collisions.shape.CollisionDiscreteVoxelShape;
 import net.minecraft.core.Direction;
@@ -12,35 +13,50 @@ import java.util.Arrays;
 @Mixin(DiscreteVoxelShape.class)
 abstract class DiscreteVoxelShapeMixin implements CollisionDiscreteVoxelShape {
 
-    // ignore race conditions on field read/write: the shape is static, so it doesn't matter
+    // Benign race: the geometry is immutable, so concurrent initialisation produces equivalent data.
     @Unique
     private CachedShapeData cachedShapeData;
 
     @Override
     public final CachedShapeData moonrise$getOrCreateCachedShapeData() {
-        if (this.cachedShapeData != null) {
-            return this.cachedShapeData;
+        final CachedShapeData cached = this.cachedShapeData;
+        if (cached != null) {
+            return cached;
         }
+        return this.moonrise$createCachedShapeData(true);
+    }
 
+    @Override
+    public final CachedShapeData moonrise$getOrCreateCachedShapeData(final boolean internRetainedGeometry) {
+        final CachedShapeData cached = this.cachedShapeData;
+        if (cached != null) {
+            if (!internRetainedGeometry) {
+                return cached;
+            }
+            // A transient shape may later become retained. Promote its cached data to the
+            // shared pool once.
+            return this.cachedShapeData = VoxelShapeInternPool.internShapeData(cached);
+        }
+        return this.moonrise$createCachedShapeData(internRetainedGeometry);
+    }
+
+    @Unique
+    private CachedShapeData moonrise$createCachedShapeData(final boolean internRetainedGeometry) {
         final DiscreteVoxelShape discreteVoxelShape = (DiscreteVoxelShape)(Object)this;
 
         final int sizeX = discreteVoxelShape.getXSize();
         final int sizeY = discreteVoxelShape.getYSize();
         final int sizeZ = discreteVoxelShape.getZSize();
-
-        final int maxIndex = sizeX * sizeY * sizeZ; // exclusive
-
-        final int longsRequired = (maxIndex + (Long.SIZE - 1)) >>> 6;
-        long[] voxelSet;
+        final int voxelCount = sizeX * sizeY * sizeZ;
+        final int longsRequired = (voxelCount + (Long.SIZE - 1)) >>> 6;
 
         final boolean isEmpty = discreteVoxelShape.isEmpty();
+        final long[] voxelSet;
 
         if (discreteVoxelShape instanceof BitSetDiscreteVoxelShape bitsetShape) {
-            voxelSet = bitsetShape.storage.toLongArray();
-            if (voxelSet.length < longsRequired) {
-                // happens when the later long values are 0L, so we need to resize
-                voxelSet = Arrays.copyOf(voxelSet, longsRequired);
-            }
+            final long[] stored = bitsetShape.storage.toLongArray();
+            // BitSet#toLongArray omits trailing zero words.
+            voxelSet = stored.length < longsRequired ? Arrays.copyOf(stored, longsRequired) : stored;
         } else {
             voxelSet = new long[longsRequired];
             if (!isEmpty) {
@@ -49,9 +65,8 @@ abstract class DiscreteVoxelShapeMixin implements CollisionDiscreteVoxelShape {
                     for (int y = 0; y < sizeY; ++y) {
                         for (int z = 0; z < sizeZ; ++z) {
                             if (discreteVoxelShape.isFull(x, y, z)) {
-                                // index = z + y*size_z + x*(size_z*size_y)
+                                // index = z + y*sizeZ + x*(sizeZ*sizeY)
                                 final int index = z + y * sizeZ + x * mulX;
-
                                 voxelSet[index >>> 6] |= 1L << index;
                             }
                         }
@@ -70,11 +85,14 @@ abstract class DiscreteVoxelShapeMixin implements CollisionDiscreteVoxelShape {
         final int maxFullY = discreteVoxelShape.lastFull(Direction.Axis.Y);
         final int maxFullZ = discreteVoxelShape.lastFull(Direction.Axis.Z);
 
-        return this.cachedShapeData = new CachedShapeData(
+        final CachedShapeData data = new CachedShapeData(
                 sizeX, sizeY, sizeZ, voxelSet,
                 minFullX, minFullY, minFullZ,
                 maxFullX, maxFullY, maxFullZ,
                 isEmpty, hasSingleAABB
         );
+
+        final CachedShapeData result = internRetainedGeometry ? VoxelShapeInternPool.internShapeData(data) : data;
+        return this.cachedShapeData = result;
     }
 }

--- a/src/main/java/ca/spottedleaf/moonrise/mixin/collisions/VoxelShapeMixin.java
+++ b/src/main/java/ca/spottedleaf/moonrise/mixin/collisions/VoxelShapeMixin.java
@@ -1,9 +1,11 @@
 package ca.spottedleaf.moonrise.mixin.collisions;
 
 import ca.spottedleaf.moonrise.common.util.FlatBitsetUtil;
+import ca.spottedleaf.moonrise.common.util.VoxelShapeInternPool;
 import ca.spottedleaf.moonrise.patches.collisions.CollisionUtil;
 import ca.spottedleaf.moonrise.patches.collisions.shape.CachedShapeData;
 import ca.spottedleaf.moonrise.patches.collisions.shape.CachedToAABBs;
+import ca.spottedleaf.moonrise.patches.collisions.shape.CollisionArrayVoxelShape;
 import ca.spottedleaf.moonrise.patches.collisions.shape.CollisionDiscreteVoxelShape;
 import ca.spottedleaf.moonrise.patches.collisions.shape.CollisionVoxelShape;
 import ca.spottedleaf.moonrise.patches.collisions.shape.MergedORCache;
@@ -26,6 +28,7 @@ import net.minecraft.world.phys.shapes.Shapes;
 import net.minecraft.world.phys.shapes.VoxelShape;
 import org.spongepowered.asm.mixin.Final;
 import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Mutable;
 import org.spongepowered.asm.mixin.Overwrite;
 import org.spongepowered.asm.mixin.Shadow;
 import org.spongepowered.asm.mixin.Unique;
@@ -42,6 +45,7 @@ abstract class VoxelShapeMixin implements CollisionVoxelShape {
 
     @Shadow
     @Final
+    @Mutable
     public DiscreteVoxelShape shape;
 
     @Unique
@@ -51,8 +55,6 @@ abstract class VoxelShapeMixin implements CollisionVoxelShape {
     @Unique
     private double offsetZ;
     @Unique
-    private AABB singleAABBRepresentation;
-    @Unique
     private double[] rootCoordinatesX;
     @Unique
     private double[] rootCoordinatesY;
@@ -61,19 +63,32 @@ abstract class VoxelShapeMixin implements CollisionVoxelShape {
 
     @Unique
     private CachedShapeData cachedShapeData;
-    @Unique
-    private boolean isEmpty;
 
+    // null = uncached, List<AABB> = materialized, CachedToAABBs = delayed offset
     @Unique
-    private CachedToAABBs cachedToAABBs;
+    private Object cachedToAABBs;
+    // Also stores the single-AABB representation when FLAG_SINGLE_AABB is set.
     @Unique
     private AABB cachedBounds;
 
+    // Pack small cache states into one field to reduce the per-shape footprint.
     @Unique
-    private Boolean isFullBlock;
+    private int cacheFlags;
 
     @Unique
-    private Boolean occludesFullBlock;
+    private static final int FLAG_EMPTY = 1;
+    @Unique
+    private static final int FLAG_SINGLE_AABB = 1 << 1;
+    @Unique
+    private static final int FLAG_FULL_BLOCK_KNOWN = 1 << 2;
+    @Unique
+    private static final int FLAG_FULL_BLOCK_VALUE = 1 << 3;
+    @Unique
+    private static final int FLAG_OCCLUDES_FULL_BLOCK_KNOWN = 1 << 4;
+    @Unique
+    private static final int FLAG_OCCLUDES_FULL_BLOCK_VALUE = 1 << 5;
+    @Unique
+    private static final int FLAG_RETAINED_GEOMETRY_INTERNED = 1 << 6;
 
     // must be power of two
     @Unique
@@ -99,7 +114,34 @@ abstract class VoxelShapeMixin implements CollisionVoxelShape {
 
     @Override
     public final AABB moonrise$getSingleAABBRepresentation() {
-        return this.singleAABBRepresentation;
+        return (this.cacheFlags & FLAG_SINGLE_AABB) != 0 ? this.cachedBounds : null;
+    }
+
+    @Unique
+    private boolean moonrise$isEmptyCached() {
+        return (this.cacheFlags & FLAG_EMPTY) != 0;
+    }
+
+    @Unique
+    private void moonrise$setFullBlockCached(final boolean value) {
+        int flags = this.cacheFlags | FLAG_FULL_BLOCK_KNOWN;
+        if (value) {
+            flags |= FLAG_FULL_BLOCK_VALUE;
+        } else {
+            flags &= ~FLAG_FULL_BLOCK_VALUE;
+        }
+        this.cacheFlags = flags;
+    }
+
+    @Unique
+    private void moonrise$setOccludesFullBlockCached(final boolean value) {
+        int flags = this.cacheFlags | FLAG_OCCLUDES_FULL_BLOCK_KNOWN;
+        if (value) {
+            flags |= FLAG_OCCLUDES_FULL_BLOCK_VALUE;
+        } else {
+            flags &= ~FLAG_OCCLUDES_FULL_BLOCK_VALUE;
+        }
+        this.cacheFlags = flags;
     }
 
     @Override
@@ -122,20 +164,19 @@ abstract class VoxelShapeMixin implements CollisionVoxelShape {
         if (list instanceof DoubleArrayList rawList) {
             final double[] raw = rawList.elements();
             final int expected = rawList.size();
-            if (raw.length == expected) {
-                return raw;
-            } else {
-                return Arrays.copyOf(raw, expected);
-            }
-        } else {
-            return list.toDoubleArray();
+            return raw.length == expected ? raw : Arrays.copyOf(raw, expected);
         }
+
+        return list.toDoubleArray();
     }
 
     @Override
     public final void moonrise$initCache() {
-        this.cachedShapeData = ((CollisionDiscreteVoxelShape)this.shape).moonrise$getOrCreateCachedShapeData();
-        this.isEmpty = this.cachedShapeData.isEmpty();
+        // Construction itself is not proof of retention.
+        this.cachedShapeData = ((CollisionDiscreteVoxelShape)(Object)this.shape).moonrise$getOrCreateCachedShapeData(false);
+        if (this.cachedShapeData.isEmpty()) {
+            this.cacheFlags |= FLAG_EMPTY;
+        }
 
         final DoubleList xList = this.getCoords(Direction.Axis.X);
         final DoubleList yList = this.getCoords(Direction.Axis.Y);
@@ -163,12 +204,67 @@ abstract class VoxelShapeMixin implements CollisionVoxelShape {
         }
 
         if (this.cachedShapeData.hasSingleAABB()) {
-            this.singleAABBRepresentation = new AABB(
+            this.cacheFlags |= FLAG_SINGLE_AABB;
+            this.cachedBounds = new AABB(
                     this.rootCoordinatesX[0] + this.offsetX, this.rootCoordinatesY[0] + this.offsetY, this.rootCoordinatesZ[0] + this.offsetZ,
                     this.rootCoordinatesX[1] + this.offsetX, this.rootCoordinatesY[1] + this.offsetY, this.rootCoordinatesZ[1] + this.offsetZ
             );
-            this.cachedBounds = this.singleAABBRepresentation;
         }
+    }
+
+    @Override
+    public final void moonrise$promoteRetainedGeometry() {
+        if ((this.cacheFlags & FLAG_RETAINED_GEOMETRY_INTERNED) != 0) {
+            return;
+        }
+
+        // ArrayVoxelShape owns the retained DoubleList fields. Canonicalise those
+        // first, then refresh the raw coordinate references cached in VoxelShape.
+        if ((Object)this instanceof CollisionArrayVoxelShape arrayShape) {
+            arrayShape.moonrise$internRetainedCoordinates();
+
+            final DoubleList xList = this.getCoords(Direction.Axis.X);
+            final DoubleList yList = this.getCoords(Direction.Axis.Y);
+            final DoubleList zList = this.getCoords(Direction.Axis.Z);
+
+            if (xList instanceof OffsetDoubleList offsetDoubleList) {
+                this.offsetX = offsetDoubleList.offset;
+                this.rootCoordinatesX = extractRawArray(offsetDoubleList.delegate);
+            } else {
+                this.offsetX = 0.0;
+                this.rootCoordinatesX = extractRawArray(xList);
+            }
+
+            if (yList instanceof OffsetDoubleList offsetDoubleList) {
+                this.offsetY = offsetDoubleList.offset;
+                this.rootCoordinatesY = extractRawArray(offsetDoubleList.delegate);
+            } else {
+                this.offsetY = 0.0;
+                this.rootCoordinatesY = extractRawArray(yList);
+            }
+
+            if (zList instanceof OffsetDoubleList offsetDoubleList) {
+                this.offsetZ = offsetDoubleList.offset;
+                this.rootCoordinatesZ = extractRawArray(offsetDoubleList.delegate);
+            } else {
+                this.offsetZ = 0.0;
+                this.rootCoordinatesZ = extractRawArray(zList);
+            }
+        }
+
+        // Promote CachedShapeData before the identity-keyed DiscreteVoxelShape pool.
+        this.cachedShapeData =
+            ((CollisionDiscreteVoxelShape)(Object)this.shape).moonrise$getOrCreateCachedShapeData(true);
+        this.shape = VoxelShapeInternPool.internDiscreteShape(this.shape);
+        this.cachedShapeData =
+            ((CollisionDiscreteVoxelShape)(Object)this.shape).moonrise$getOrCreateCachedShapeData(true);
+
+        if (this.cachedBounds != null
+            && this.offsetX == 0.0 && this.offsetY == 0.0 && this.offsetZ == 0.0) {
+            this.cachedBounds = VoxelShapeInternPool.internAABB(this.cachedBounds);
+        }
+
+        this.cacheFlags |= FLAG_RETAINED_GEOMETRY_INTERNED;
     }
 
     @Override
@@ -181,7 +277,7 @@ abstract class VoxelShapeMixin implements CollisionVoxelShape {
 
     @Override
     public final VoxelShape moonrise$getFaceShapeClamped(final Direction direction) {
-        if (this.isEmpty) {
+        if (this.moonrise$isEmptyCached()) {
             return (VoxelShape)(Object)this;
         }
         if ((VoxelShape)(Object)this == Shapes.block()) {
@@ -190,19 +286,17 @@ abstract class VoxelShapeMixin implements CollisionVoxelShape {
 
         VoxelShape[] cache = this.faceShapeClampedCache;
         if (cache != null) {
-            final VoxelShape ret = cache[direction.ordinal()];
-            if (ret != null) {
-                return ret;
+            final VoxelShape cached = cache[direction.ordinal()];
+            if (cached != null) {
+                return cached;
             }
         }
-
 
         if (cache == null) {
             this.faceShapeClampedCache = cache = new VoxelShape[6];
         }
 
         final Direction.Axis axis = direction.getAxis();
-
         final VoxelShape ret;
 
         if (direction.getAxisDirection() == Direction.AxisDirection.POSITIVE) {
@@ -220,43 +314,42 @@ abstract class VoxelShapeMixin implements CollisionVoxelShape {
         }
 
         cache[direction.ordinal()] = ret;
-
         return ret;
     }
 
     @Unique
     private boolean computeOccludesFullBlock() {
-        if (this.isEmpty) {
-            this.occludesFullBlock = Boolean.FALSE;
+        if (this.moonrise$isEmptyCached()) {
+            this.moonrise$setOccludesFullBlockCached(false);
             return false;
         }
 
         if (this.moonrise$isFullBlock()) {
-            this.occludesFullBlock = Boolean.TRUE;
+            this.moonrise$setOccludesFullBlockCached(true);
             return true;
         }
 
-        final AABB singleAABB = this.singleAABBRepresentation;
+        final AABB singleAABB = this.moonrise$getSingleAABBRepresentation();
         if (singleAABB != null) {
             // check if the bounding box encloses the full cube
             final boolean ret =
                     (singleAABB.minY <= CollisionUtil.COLLISION_EPSILON && singleAABB.maxY >= (1 - CollisionUtil.COLLISION_EPSILON)) &&
                     (singleAABB.minX <= CollisionUtil.COLLISION_EPSILON && singleAABB.maxX >= (1 - CollisionUtil.COLLISION_EPSILON)) &&
                     (singleAABB.minZ <= CollisionUtil.COLLISION_EPSILON && singleAABB.maxZ >= (1 - CollisionUtil.COLLISION_EPSILON));
-            this.occludesFullBlock = Boolean.valueOf(ret);
+            this.moonrise$setOccludesFullBlockCached(ret);
             return ret;
         }
 
         final boolean ret = !Shapes.joinIsNotEmpty(Shapes.block(), ((VoxelShape)(Object)this), BooleanOp.ONLY_FIRST);
-        this.occludesFullBlock = Boolean.valueOf(ret);
+        this.moonrise$setOccludesFullBlockCached(ret);
         return ret;
     }
 
     @Override
     public final boolean moonrise$occludesFullBlock() {
-        final Boolean ret = this.occludesFullBlock;
-        if (ret != null) {
-            return ret.booleanValue();
+        final int flags = this.cacheFlags;
+        if ((flags & FLAG_OCCLUDES_FULL_BLOCK_KNOWN) != 0) {
+            return (flags & FLAG_OCCLUDES_FULL_BLOCK_VALUE) != 0;
         }
 
         return this.computeOccludesFullBlock();
@@ -264,8 +357,9 @@ abstract class VoxelShapeMixin implements CollisionVoxelShape {
 
     @Override
     public final boolean moonrise$occludesFullBlockIfCached() {
-        final Boolean ret = this.occludesFullBlock;
-        return ret != null ? ret.booleanValue() : false;
+        final int flags = this.cacheFlags;
+        return (flags & FLAG_OCCLUDES_FULL_BLOCK_KNOWN) != 0
+            && (flags & FLAG_OCCLUDES_FULL_BLOCK_VALUE) != 0;
     }
 
     @Unique
@@ -280,7 +374,7 @@ abstract class VoxelShapeMixin implements CollisionVoxelShape {
             return other;
         }
 
-        if (this.isEmpty) {
+        if (this.moonrise$isEmptyCached()) {
             return other;
         }
 
@@ -331,7 +425,7 @@ abstract class VoxelShapeMixin implements CollisionVoxelShape {
      */
     @Overwrite
     public boolean isEmpty() {
-        return this.isEmpty;
+        return this.moonrise$isEmptyCached();
     }
 
     /**
@@ -340,7 +434,7 @@ abstract class VoxelShapeMixin implements CollisionVoxelShape {
      */
     @Overwrite
     public VoxelShape singleEncompassing() {
-        if (this.isEmpty) {
+        if (this.moonrise$isEmptyCached()) {
             return Shapes.empty();
         }
         return Shapes.create(this.bounds());
@@ -449,7 +543,7 @@ abstract class VoxelShapeMixin implements CollisionVoxelShape {
      */
     @Overwrite
     public double collide(final Direction.Axis axis, final AABB source, final double source_move) {
-        if (this.isEmpty) {
+        if (this.moonrise$isEmptyCached()) {
             return source_move;
         }
         if (Math.abs(source_move) < CollisionUtil.COLLISION_EPSILON) {
@@ -486,7 +580,7 @@ abstract class VoxelShapeMixin implements CollisionVoxelShape {
      */
     @Overwrite
     public VoxelShape move(final double x, final double y, final double z) {
-        if (this.isEmpty) {
+        if (this.moonrise$isEmptyCached()) {
             return Shapes.empty();
         }
 
@@ -497,9 +591,17 @@ abstract class VoxelShapeMixin implements CollisionVoxelShape {
             offsetList(this.rootCoordinatesZ, this.offsetZ + z)
         );
 
-        final CachedToAABBs cachedToAABBs = this.cachedToAABBs;
-        if (cachedToAABBs != null) {
-            ((VoxelShapeMixin)(Object)ret).cachedToAABBs = CachedToAABBs.offset(cachedToAABBs, x, y, z);
+        final Object cached = this.cachedToAABBs;
+        if (cached instanceof CachedToAABBs offsetCache) {
+            ((VoxelShapeMixin)(Object)ret).cachedToAABBs = offsetCache.offset(x, y, z);
+        } else if (cached instanceof List<?> list) {
+            if (x == 0.0 && y == 0.0 && z == 0.0) {
+                ((VoxelShapeMixin)(Object)ret).cachedToAABBs = list;
+            } else {
+                @SuppressWarnings("unchecked")
+                final List<AABB> aabbs = (List<AABB>)list;
+                ((VoxelShapeMixin)(Object)ret).cachedToAABBs = new CachedToAABBs(aabbs, x, y, z);
+            }
         }
 
         return ret;
@@ -507,12 +609,15 @@ abstract class VoxelShapeMixin implements CollisionVoxelShape {
 
     @Unique
     private List<AABB> toAabbsUncached() {
-        final List<AABB> ret;
-        if (this.singleAABBRepresentation != null) {
+        final ArrayList<AABB> ret;
+        final AABB singleAABB = this.moonrise$getSingleAABBRepresentation();
+
+        if (singleAABB != null) {
             ret = new ArrayList<>(1);
-            ret.add(this.singleAABBRepresentation);
+            ret.add(singleAABB);
         } else {
             ret = new ArrayList<>();
+
             final double[] coordsX = this.rootCoordinatesX;
             final double[] coordsY = this.rootCoordinatesY;
             final double[] coordsZ = this.rootCoordinatesZ;
@@ -520,24 +625,32 @@ abstract class VoxelShapeMixin implements CollisionVoxelShape {
             final double offX = this.offsetX;
             final double offY = this.offsetY;
             final double offZ = this.offsetZ;
+            final boolean hasNoOffset = offX == 0.0 && offY == 0.0 && offZ == 0.0;
 
             this.shape.forAllBoxes((final int minX, final int minY, final int minZ,
                                     final int maxX, final int maxY, final int maxZ) -> {
-                ret.add(new AABB(
+                AABB box = new AABB(
                         coordsX[minX] + offX,
                         coordsY[minY] + offY,
                         coordsZ[minZ] + offZ,
 
-
                         coordsX[maxX] + offX,
                         coordsY[maxY] + offY,
                         coordsZ[maxZ] + offZ
-                ));
+                );
+
+                if (hasNoOffset) {
+                    box = VoxelShapeInternPool.internAABB(box);
+                }
+
+                ret.add(box);
             }, true);
+
+            // retained for the lifetime of the shape
+            ret.trimToSize();
         }
 
-        // cache result
-        this.cachedToAABBs = new CachedToAABBs(ret, false, 0.0, 0.0, 0.0);
+        this.cachedToAABBs = ret;
 
         return ret;
     }
@@ -548,33 +661,33 @@ abstract class VoxelShapeMixin implements CollisionVoxelShape {
      */
     @Overwrite
     public List<AABB> toAabbs() {
-        CachedToAABBs cachedToAABBs = this.cachedToAABBs;
-        if (cachedToAABBs != null) {
-            if (!cachedToAABBs.isOffset()) {
-                return cachedToAABBs.aabbs();
-            }
+        final Object cached = this.cachedToAABBs;
 
-            // all we need to do is offset the cache
-            cachedToAABBs = cachedToAABBs.removeOffset();
-            // update cache
-            this.cachedToAABBs = cachedToAABBs;
-
-            return cachedToAABBs.aabbs();
+        if (cached instanceof List<?> list) {
+            @SuppressWarnings("unchecked")
+            final List<AABB> ret = (List<AABB>)list;
+            return ret;
         }
 
-        // make new cache
+        if (cached instanceof CachedToAABBs offsetCache) {
+            final List<AABB> ret = offsetCache.removeOffset();
+            this.cachedToAABBs = ret;
+            return ret;
+        }
+
         return this.toAabbsUncached();
     }
 
     @Unique
     private boolean computeFullBlock() {
-        Boolean ret;
-        if (this.isEmpty) {
-            ret = Boolean.FALSE;
+        boolean ret;
+
+        if (this.moonrise$isEmptyCached()) {
+            ret = false;
         } else if ((VoxelShape)(Object)this == Shapes.block()) {
-            ret = Boolean.TRUE;
+            ret = true;
         } else {
-            final AABB singleAABB = this.singleAABBRepresentation;
+            final AABB singleAABB = this.moonrise$getSingleAABBRepresentation();
             if (singleAABB == null) {
                 final CachedShapeData shapeData = this.cachedShapeData;
                 final int sMinX = shapeData.minFullX();
@@ -600,45 +713,43 @@ abstract class VoxelShapeMixin implements CollisionVoxelShape {
 
                     final long[] bitset = shapeData.voxelSet();
 
-                    ret = Boolean.TRUE;
+                    ret = true;
 
                     check_full:
                     for (int x = sMinX; x < sMaxX; ++x) {
                         for (int y = sMinY; y < sMaxY; ++y) {
                             final int baseIndex = y*sizeZ + x*(sizeZ*sizeY);
                             if (!FlatBitsetUtil.isRangeSet(bitset, baseIndex + sMinZ, baseIndex + sMaxZ)) {
-                                ret = Boolean.FALSE;
+                                ret = false;
                                 break check_full;
                             }
                         }
                     }
                 } else {
-                    ret = Boolean.FALSE;
+                    ret = false;
                 }
             } else {
-                ret = Boolean.valueOf(
+                ret =
                         Math.abs(singleAABB.minX) <= CollisionUtil.COLLISION_EPSILON &&
-                           Math.abs(singleAABB.minY) <= CollisionUtil.COLLISION_EPSILON &&
-                           Math.abs(singleAABB.minZ) <= CollisionUtil.COLLISION_EPSILON &&
+                        Math.abs(singleAABB.minY) <= CollisionUtil.COLLISION_EPSILON &&
+                        Math.abs(singleAABB.minZ) <= CollisionUtil.COLLISION_EPSILON &&
 
-                           Math.abs(1.0 - singleAABB.maxX) <= CollisionUtil.COLLISION_EPSILON &&
-                           Math.abs(1.0 - singleAABB.maxY) <= CollisionUtil.COLLISION_EPSILON &&
-                           Math.abs(1.0 - singleAABB.maxZ) <= CollisionUtil.COLLISION_EPSILON
-                );
+                        Math.abs(1.0 - singleAABB.maxX) <= CollisionUtil.COLLISION_EPSILON &&
+                        Math.abs(1.0 - singleAABB.maxY) <= CollisionUtil.COLLISION_EPSILON &&
+                        Math.abs(1.0 - singleAABB.maxZ) <= CollisionUtil.COLLISION_EPSILON;
             }
         }
 
-        this.isFullBlock = ret;
-
-        return ret.booleanValue();
+        this.moonrise$setFullBlockCached(ret);
+        return ret;
     }
 
     @Override
     public final boolean moonrise$isFullBlock() {
-        final Boolean ret = this.isFullBlock;
+        final int flags = this.cacheFlags;
 
-        if (ret != null) {
-            return ret.booleanValue();
+        if ((flags & FLAG_FULL_BLOCK_KNOWN) != 0) {
+            return (flags & FLAG_FULL_BLOCK_VALUE) != 0;
         }
 
         return this.computeFullBlock();
@@ -670,7 +781,7 @@ abstract class VoxelShapeMixin implements CollisionVoxelShape {
      */
     @Overwrite
     public BlockHitResult clip(final Vec3 from, final Vec3 to, final BlockPos offset) {
-        if (this.isEmpty) {
+        if (this.moonrise$isEmptyCached()) {
             return null;
         }
 
@@ -684,7 +795,7 @@ abstract class VoxelShapeMixin implements CollisionVoxelShape {
         final double fromBehindOffsetY = fromBehind.y - (double)offset.getY();
         final double fromBehindOffsetZ = fromBehind.z - (double)offset.getZ();
 
-        final AABB singleAABB = this.singleAABBRepresentation;
+        final AABB singleAABB = this.moonrise$getSingleAABBRepresentation();
         if (singleAABB != null) {
             if (singleAABB.contains(fromBehindOffsetX, fromBehindOffsetY, fromBehindOffsetZ)) {
                 return new BlockHitResult(fromBehind, Direction.getApproximateNearest(directionOpposite.x, directionOpposite.y, directionOpposite.z).getOpposite(), offset, true);
@@ -705,7 +816,7 @@ abstract class VoxelShapeMixin implements CollisionVoxelShape {
      */
     @Overwrite
     public AABB bounds() {
-        if (this.isEmpty) {
+        if (this.moonrise$isEmptyCached()) {
             throw Util.pauseInIde(new UnsupportedOperationException("No bounds for empty shape."));
         }
         AABB cached = this.cachedBounds;
@@ -733,6 +844,10 @@ abstract class VoxelShapeMixin implements CollisionVoxelShape {
                 coordsY[shapeData.maxFullY()] + offY,
                 coordsZ[shapeData.maxFullZ()] + offZ
         );
+
+        if (offX == 0.0 && offY == 0.0 && offZ == 0.0) {
+            cached = VoxelShapeInternPool.internAABB(cached);
+        }
 
         this.cachedBounds = cached;
         return cached;
@@ -800,11 +915,11 @@ abstract class VoxelShapeMixin implements CollisionVoxelShape {
      */
     @Overwrite
     public VoxelShape optimize() {
-        if (this.isEmpty) {
+        if (this.moonrise$isEmptyCached()) {
             return Shapes.empty();
         }
 
-        if (this.singleAABBRepresentation != null) {
+        if (this.moonrise$getSingleAABBRepresentation() != null) {
             // note: the isFullBlock() is fuzzy, and Shapes.create() is also fuzzy which would return block()
             return this.moonrise$isFullBlock() ? Shapes.block() : (VoxelShape)(Object)this;
         }
@@ -874,7 +989,7 @@ abstract class VoxelShapeMixin implements CollisionVoxelShape {
      */
     @Overwrite
     public Optional<Vec3> closestPointTo(final Vec3 point) {
-        if (this.isEmpty) {
+        if (this.moonrise$isEmptyCached()) {
             return Optional.empty();
         }
 

--- a/src/main/java/ca/spottedleaf/moonrise/patches/collisions/shape/CachedShapeData.java
+++ b/src/main/java/ca/spottedleaf/moonrise/patches/collisions/shape/CachedShapeData.java
@@ -1,5 +1,8 @@
 package ca.spottedleaf.moonrise.patches.collisions.shape;
 
+/**
+ * Cached collision data. The voxelSet array must not be modified after construction because instances may be shared.
+ */
 public record CachedShapeData(
         int sizeX, int sizeY, int sizeZ,
         long[] voxelSet,

--- a/src/main/java/ca/spottedleaf/moonrise/patches/collisions/shape/CachedToAABBs.java
+++ b/src/main/java/ca/spottedleaf/moonrise/patches/collisions/shape/CachedToAABBs.java
@@ -1,16 +1,16 @@
 package ca.spottedleaf.moonrise.patches.collisions.shape;
 
 import net.minecraft.world.phys.AABB;
+
 import java.util.ArrayList;
 import java.util.List;
 
 public record CachedToAABBs(
         List<AABB> aabbs,
-        boolean isOffset,
         double offX, double offY, double offZ
 ) {
 
-    public CachedToAABBs removeOffset() {
+    public List<AABB> removeOffset() {
         final List<AABB> toOffset = this.aabbs;
         final double offX = this.offX;
         final double offY = this.offY;
@@ -22,18 +22,19 @@ public record CachedToAABBs(
             ret.add(toOffset.get(i).move(offX, offY, offZ));
         }
 
-        return new CachedToAABBs(ret, false, 0.0, 0.0, 0.0);
+        return ret;
     }
 
-    public static CachedToAABBs offset(final CachedToAABBs cache, final double offX, final double offY, final double offZ) {
+    public CachedToAABBs offset(final double offX, final double offY, final double offZ) {
         if (offX == 0.0 && offY == 0.0 && offZ == 0.0) {
-            return cache;
+            return this;
         }
 
-        final double resX = cache.offX + offX;
-        final double resY = cache.offY + offY;
-        final double resZ = cache.offZ + offZ;
-
-        return new CachedToAABBs(cache.aabbs, true, resX, resY, resZ);
+        return new CachedToAABBs(
+            this.aabbs,
+            this.offX + offX,
+            this.offY + offY,
+            this.offZ + offZ
+        );
     }
 }

--- a/src/main/java/ca/spottedleaf/moonrise/patches/collisions/shape/CollisionArrayVoxelShape.java
+++ b/src/main/java/ca/spottedleaf/moonrise/patches/collisions/shape/CollisionArrayVoxelShape.java
@@ -1,0 +1,9 @@
+package ca.spottedleaf.moonrise.patches.collisions.shape;
+
+public interface CollisionArrayVoxelShape {
+
+    /**
+     * Canonicalise coordinate lists only when this shape is known to be retained.
+     */
+    public void moonrise$internRetainedCoordinates();
+}

--- a/src/main/java/ca/spottedleaf/moonrise/patches/collisions/shape/CollisionDiscreteVoxelShape.java
+++ b/src/main/java/ca/spottedleaf/moonrise/patches/collisions/shape/CollisionDiscreteVoxelShape.java
@@ -4,4 +4,6 @@ public interface CollisionDiscreteVoxelShape {
 
     public CachedShapeData moonrise$getOrCreateCachedShapeData();
 
+    public CachedShapeData moonrise$getOrCreateCachedShapeData(boolean internRetainedGeometry);
+
 }

--- a/src/main/java/ca/spottedleaf/moonrise/patches/collisions/shape/CollisionVoxelShape.java
+++ b/src/main/java/ca/spottedleaf/moonrise/patches/collisions/shape/CollisionVoxelShape.java
@@ -23,8 +23,11 @@ public interface CollisionVoxelShape {
     // rets null if not possible to represent this shape as one AABB
     public AABB moonrise$getSingleAABBRepresentation();
 
-    // ONLY USE INTERNALLY, ONLY FOR INITIALISING IN CONSTRUCTOR: VOXELSHAPES ARE STATIC
+    // Only use internally during construction. VoxelShape geometry is immutable afterwards.
     public void moonrise$initCache();
+
+    // Called only when a long-lived owner (currently BlockState caches) retains the shape.
+    public void moonrise$promoteRetainedGeometry();
 
     // this returns empty if not clamped to 1.0 or 0.0 depending on direction
     public VoxelShape moonrise$getFaceShapeClamped(final Direction direction);


### PR DESCRIPTION
## Summary

This PR reduces memory retained by `VoxelShape` collision caches by sharing immutable geometry data that is duplicated across many shapes.

The main change is that geometry is no longer interned during normal `VoxelShape` construction. Shapes created by collisions, joins or moves can be short-lived, so interning them globally would add unnecessary runtime overhead.

Instead, retained geometry is promoted when it reaches a known long-lived owner, currently the `BlockState` collision caches.

## Changes

- Added bounded interning for coordinate lists, cached voxel data, discrete voxel shapes and cached AABBs.
- Added retained-geometry promotion for shapes stored in `BlockState` caches.
- Kept transient/runtime-generated shapes out of the global pools.
- Reduced duplicated retained cache data.
- Kept all pools bounded to avoid unbounded process-lifetime growth.

## Memory impact

Measured against the unmodified base using the same world/config snapshot and a full GC before each measurement:

| | Heap after Full GC |
|---|---:|
| Baseline median | 217.932 MiB |
| Optimized median | 137.806 MiB |
| Saved | **80.126 MiB (36.767%)** |

Some of the largest retained object reductions:

| Type | Baseline | Optimized |
|---|---:|---:|
| `CachedShapeData` | 170,165 | 1,611 |
| `BitSetDiscreteVoxelShape` | 170,165 | 1,611 |
| `DoubleArrayList` | 353,936 | 4,438 |
| `AABB` | 417,470 | 1,613 |
| `CachedToAABBs` | 171,389 | 0 |

The number of `ArrayVoxelShape` instances itself stays unchanged, so the reduction comes from sharing duplicated retained data rather than avoiding shape creation.

## Validation

Functional behaviour was compared against the base revision using a deterministic black-box oracle based on public Minecraft APIs.

Both versions produced byte-identical results, and the Mixin audit passes for both builds.

A separate runtime A/B benchmark also showed no material regression in the collision and shape hot paths.