### PR TITLE
Lazily allocate ticking block lists

### DIFF
--- a/src/main/java/ca/spottedleaf/moonrise/mixin/block_counting/LevelChunkSectionMixin.java
+++ b/src/main/java/ca/spottedleaf/moonrise/mixin/block_counting/LevelChunkSectionMixin.java
@@ -68,7 +68,17 @@ abstract class LevelChunkSectionMixin implements BlockCountingChunkSection {
     private short specialCollidingBlocks;
 
     @Unique
-    private final ShortList tickingBlocks = new ShortList();
+    private ShortList tickingBlocks;
+
+    @Unique
+    private ShortList moonrise$getOrCreateTickingBlockList() {
+        ShortList ret = this.tickingBlocks;
+        if (ret == null) {
+            ret = new ShortList();
+            this.tickingBlocks = ret;
+        }
+        return ret;
+    }
 
     @Override
     public final boolean moonrise$hasSpecialCollidingBlocks() {
@@ -116,13 +126,12 @@ abstract class LevelChunkSectionMixin implements BlockCountingChunkSection {
         final boolean oldTicking = oldState.isRandomlyTicking();
         final boolean newTicking = newState.isRandomlyTicking();
         if (oldTicking != newTicking) {
-            final ShortList tickingBlocks = this.tickingBlocks;
             final short position = (short)(x | (z << 4) | (y << (4+4)));
 
             if (oldTicking) {
-                tickingBlocks.remove(position);
+                this.tickingBlocks.remove(position);
             } else {
-                tickingBlocks.add(position);
+                this.moonrise$getOrCreateTickingBlockList().add(position);
             }
         }
     }
@@ -139,7 +148,9 @@ abstract class LevelChunkSectionMixin implements BlockCountingChunkSection {
         this.tickingBlockCount = (short)0;
         this.tickingFluidCount = (short)0;
         this.specialCollidingBlocks = (short)0;
-        this.tickingBlocks.clear();
+        if (this.tickingBlocks != null) {
+            this.tickingBlocks.clear();
+        }
 
         if (this.maybeHas((final BlockState state) -> !state.isAir())) {
             final PalettedContainer.Data<BlockState> data = this.states.data;
@@ -176,7 +187,7 @@ abstract class LevelChunkSectionMixin implements BlockCountingChunkSection {
                     final short[] raw = coordinates.elements();
                     final int rawLen = raw.length;
 
-                    final ShortList tickingBlocks = this.tickingBlocks;
+                    final ShortList tickingBlocks = this.moonrise$getOrCreateTickingBlockList();
 
                     tickingBlocks.setMinCapacity(Math.min((rawLen + tickingBlocks.size()) * 3 / 2, 16*16*16));
 


### PR DESCRIPTION
## Summary

This PR reduces memory retained by `LevelChunkSection` by lazily allocating the `ShortList` used for randomly ticking blocks.

Most loaded sections do not contain randomly ticking blocks, but currently every section retains its own list.

This revisits #108, which was originally a port of PaperMC/Paper#11500. That PR also changed parts of the random-ticking path around the nullable list. This version keeps the change limited to the allocation itself and leaves that path unchanged.

## Changes

- Allocate the ticking block list on first use instead of for every `LevelChunkSection`.
- Only allocate the list during `recalcBlockCounts()` when a randomly ticking block is found.
- Keep an allocated list when it becomes empty so it can be reused.
- Keep the existing random-ticking path unchanged.

## Memory impact

Measured against the unmodified base using the same world/config snapshot and a full GC before each measurement:

| | Heap after Full GC |
| --- | ---: |
| Baseline median | 274.286 MiB |
| Optimized median | 267.350 MiB |
| Saved | **6.937 MiB (2.529%)** |

The test had 30,000 loaded sections.

| | Baseline | Optimized |
| --- | ---: | ---: |
| `ShortList` | 30,000 | 997 |

29,003 of the 30,000 sections did not contain randomly ticking blocks and no longer retain a ticking block list.

The exact saving depends on how many loaded sections contain randomly ticking blocks.

As a rough example, scaling the same result to 100,000 loaded sections with a similar distribution would save around 23 MiB.

## Validation

Tested the lazy allocation, add/remove behavior, reuse of an empty list and `recalcBlockCounts()`.

Mixin audit, Fabric tests and the full build pass.