### PR TITLE
Reuse wrapped sections for ImposterProtoChunk

### DIFF
--- a/src/main/java/ca/spottedleaf/moonrise/mixin/starlight/chunk/ChunkAccessAccessorMixin.java
+++ b/src/main/java/ca/spottedleaf/moonrise/mixin/starlight/chunk/ChunkAccessAccessorMixin.java
@@ -1,0 +1,13 @@
+package ca.spottedleaf.moonrise.mixin.starlight.chunk;
+
+import net.minecraft.world.level.chunk.ChunkAccess;
+import net.minecraft.world.level.chunk.LevelChunkSection;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.gen.Accessor;
+
+@Mixin(ChunkAccess.class)
+interface ChunkAccessAccessorMixin {
+
+    @Accessor("sections")
+    LevelChunkSection[] starlight$getSections();
+}

--- a/src/main/java/ca/spottedleaf/moonrise/mixin/starlight/chunk/ImposterProtoChunkMixin.java
+++ b/src/main/java/ca/spottedleaf/moonrise/mixin/starlight/chunk/ImposterProtoChunkMixin.java
@@ -8,6 +8,7 @@ import net.minecraft.world.level.LevelHeightAccessor;
 import net.minecraft.world.level.biome.Biome;
 import net.minecraft.world.level.chunk.ImposterProtoChunk;
 import net.minecraft.world.level.chunk.LevelChunk;
+import net.minecraft.world.level.chunk.LevelChunkSection;
 import net.minecraft.world.level.chunk.PalettedContainerFactory;
 import net.minecraft.world.level.chunk.ProtoChunk;
 import net.minecraft.world.level.chunk.UpgradeData;
@@ -16,6 +17,9 @@ import org.jetbrains.annotations.Nullable;
 import org.spongepowered.asm.mixin.Final;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Shadow;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 
 @Mixin(ImposterProtoChunk.class)
 abstract class ImposterProtoChunkMixin extends ProtoChunk implements StarlightChunk {
@@ -26,6 +30,15 @@ abstract class ImposterProtoChunkMixin extends ProtoChunk implements StarlightCh
 
     public ImposterProtoChunkMixin(final ChunkPos chunkPos, final UpgradeData upgradeData, final LevelHeightAccessor levelHeightAccessor, final PalettedContainerFactory palettedContainerFactory, @Nullable final BlendingData blendingData) {
         super(chunkPos, upgradeData, levelHeightAccessor, palettedContainerFactory, blendingData);
+    }
+
+    @Inject(
+        method = "<init>",
+        at = @At("RETURN")
+    )
+    private void reuseWrappedSections(final CallbackInfo ci) {
+        final LevelChunkSection[] sections = ((ChunkAccessAccessorMixin)(Object)this).starlight$getSections();
+        System.arraycopy(this.wrapped.getSections(), 0, sections, 0, sections.length);
     }
 
     @Override

--- a/src/main/resources/moonrise.mixins.json
+++ b/src/main/resources/moonrise.mixins.json
@@ -116,6 +116,7 @@
         "random_ticking.ServerLevelMixin",
         "serverlist.ConnectionMixin",
         "starlight.blockstate.BlockStateBaseMixin",
+        "starlight.chunk.ChunkAccessAccessorMixin",
         "starlight.chunk.ChunkAccessMixin",
         "starlight.chunk.EmptyLevelChunkMixin",
         "starlight.chunk.ImposterProtoChunkMixin",


### PR DESCRIPTION
## Summary

This PR reduces memory retained by `ImposterProtoChunk` by reusing the `LevelChunkSection` objects from the wrapped `LevelChunk`.

`ImposterProtoChunk` keeps its own section array, but the section objects created for it are not needed once the wrapped chunk is available.

## Changes

- Reuse the wrapped chunk's `LevelChunkSection` objects.
- Keep the existing section array instead of replacing the final field.
- Add a read-only accessor for the internal section array.

## Memory impact

Measured against the unmodified base using the same world/config snapshot and a full GC before each measurement:

| | Heap after Full GC |
| --- | ---: |
| Baseline median | 274.551 MiB |
| Optimized median | 265.733 MiB |
| Saved | **8.818 MiB (3.212%)** |

The test had 625 `LevelChunk` and 625 `ImposterProtoChunk` instances.

| | Baseline | Optimized |
| --- | ---: | ---: |
| `LevelChunkSection` | 30,000 | 15,000 |
| `PalettedContainer` | 60,000 | 30,000 |
| `PalettedContainer.Data` | 60,000 | 30,000 |
| `SingleValuePalette` | 55,002 | 25,002 |
| `ZeroBitStorage` | 55,002 | 25,002 |
| `LevelChunkSection[]` | 1,257 | 1,257 |

The heap dump shows that all 15,000 sections retained by the 625 imposters are replaced with references to the sections of their wrapped chunks.

The removed section object graph accounts for about 7.8 MiB in this test.

Part of this saving overlaps with #196, since the discarded sections currently also retain their ticking block lists. The changes themselves are independent.

## Validation

Compared the baseline and optimized implementations using the same chunk fixture.

Verified section identity, block, fluid and biome reads, Starlight state, and both read-only and writable `ImposterProtoChunk` behavior.

Mixin audit, Fabric tests and the full build pass.